### PR TITLE
Ammar

### DIFF
--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_01.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_01.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the Read Acces in Supervisor mode for Level1        #
+#                                                                                               #
+# Description:                - load page fault for read access.                                #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT
+    
+main:
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    CLEAR_REG(a2)                                                   # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_02.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_02.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the write Acces in Supervisor mode for Level1       #
+#                                                                                               #
+# Description:                - store/AMO page fault for write access.                          #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT
+    
+main:
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5   
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_03.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_03.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the execute Acces in Supervisor mode for Level1     #
+#                                                                                               #
+# Description:                - Instruction page fault for execute access.                      #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT
+    
+main:
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    li t0,ALL_F_S                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_04.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_04.S
@@ -1,0 +1,56 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the Read Acces in User mode for Level1              #
+#                                                                                               #
+# Description:                - load page fault for read access.                                #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                            # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                             # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT    
+main:      
+    la a1,code                                                             # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                           # generrates the VA for label code
+    mv s5,a0                                                               # move VA to s5
+    mv s10,s5                                                              # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+    
+    la a1,arr                                                              # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                           # generrates the VA for label arr
+    mv s6,a0                                                               # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2s   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U  | PTE_X | PTE_W | PTE_R )         # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1   
+    
+    SATP_SETUP_SV32                                                        # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                                   # changes mode M to U and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_05.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_05.S
@@ -1,0 +1,56 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal:   Set PTE.V = 0 and test the write Acces in user mode for Level1           #
+#                                                                                               #
+# Description:         - store/AMO page fault for write access.                                 #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                             # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                              # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT
+    
+main:
+    la a1,code                                                              # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                            # generrates the VA for label code
+    mv s5,a0                                                                # move VA to s5
+    mv s10,s5                                                               # move the VA of label code to s10 that will be compared later
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+
+    la a1,arr                                                                # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                             # generrates the VA for label arr
+    mv s6,a0                                                                 # move VA to s6
+    CLEAR_REG(a2)                                                            # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )            # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                   # setup the PTE for level1   
+         
+    SATP_SETUP_SV32                                                          # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                                     # changes mode M to U and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                            # trap handler      
+COREV_VERIF_EXIT_LOGIC                                                       # exit logic 
+RVTEST_DATA_SECTION                                                          # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_06.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_06.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the execute Acces in User mode for Level1           #
+#                                                                                               #
+# Description:                - Instruction page fault for execute access.                      #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT
+    
+main:
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                            # changes mode M to U and set the MEPC value to s5
+
+code:
+    li t0,ALL_F_S                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_07.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_07.S
@@ -1,0 +1,64 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the Read Acces in Supervisor mode for Level0        #
+#                                                                                               #
+# Description:                - load page fault for read access.                                #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT
+    
+main:
+
+    la a1,pgtb_l0                                                   # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x010)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_08.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_08.S
@@ -1,0 +1,66 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the write Acces in Supervisor mode for Level0       #
+#                                                                                               #
+# Description:                - store/AMO page fault for write access.                          #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT
+    
+main:
+
+    la a1,pgtb_l0                                                   # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    CLEAR_REG(a2)                                                   # clear the reg a2
+    GEN_VA(a1, a0, 0x100, 0x010)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2s    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_09.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_09.S
@@ -1,0 +1,63 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the execute Acces in Supervisor mode for Level0     #
+#                                                                                               #
+# Description:                - Instruction page fault for execute access.                      #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT
+    
+main:
+    la a1,pgtb_l0                                                   # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    CLEAR_REG(a2)                                                   # clear the reg a2
+    GEN_VA(a1, a0, 0x100, 0x010)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    li t0,ALL_F_S                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_10.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_10.S
@@ -1,0 +1,64 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the Read Acces in User mode for Level0             #
+#                                                                                               #
+# Description:                - load page fault for read access.                                #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                            # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                             # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT    
+main:      
+    
+    la a1,pgtb_l0                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                           # generrates the VA for label code
+    CLEAR_REG(a2)                                                          # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+
+    la a1,code                                                             # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                           # generrates the VA for label code
+    mv s5,a0                                                               # move VA to s5
+    mv s10,s5                                                              # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                          # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
+    
+    la a1,arr                                                              # loads the address of label arr
+    CLEAR_REG(a2)                                                          # clear the reg a2
+    GEN_VA(a1, a0, 0x100, 0x010)                                           # generrates the VA for label arr
+    mv s6,a0                                                               # move VA to s6
+    CLEAR_REG(a2)                                                          # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U  | PTE_X | PTE_W | PTE_R )         # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1   
+    
+    SATP_SETUP_SV32                                                        # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                                   # changes mode M to U and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_11.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_11.S
@@ -1,0 +1,64 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal:   Set PTE.V = 0 and test the write Acces in user mode for Level0           #
+#                                                                                               #
+# Description:         - store/AMO page fault for write access.                                 #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                              # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                               # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT
+    
+main:
+
+    la a1,pgtb_l0                                                            # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                             # generrates the VA for label code
+    CLEAR_REG(a2)                                                            # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                                    # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                   # setup the PTE for level1
+
+    la a1,code                                                               # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                             # generrates the VA for label code
+    mv s5,a0                                                                 # move VA to s5
+    mv s10,s5                                                                # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                            # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )    # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                   # setup the PTE for level1
+
+    la a1,arr                                                                # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                                             # generrates the VA for label arr
+    mv s6,a0                                                                 # move VA to s6
+    CLEAR_REG(a2)                                                            # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )            # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                   # setup the PTE for level1   
+         
+    SATP_SETUP_SV32                                                          # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                                     # changes mode M to U and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+    j exit
+
+ABit_trap_handler                                                            # trap handler      
+COREV_VERIF_EXIT_LOGIC                                                       # exit logic 
+RVTEST_DATA_SECTION                                                          # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/InValid-Permission_of_PTE_12.S
+++ b/cva6/tests/custom/sv32/InValid-Permission_of_PTE_12.S
@@ -1,0 +1,63 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Set PTE.V = 0 and test the execute Acces in User mode for Level0           #
+#                                                                                               #
+# Description:                - Instruction page fault for execute access.                      #    
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         In-Valid Permission of PTE                                               #                
+#                                                                                               #   
+# Feature Discription: If PTE does not have Valid (pte.V=0) permission, then accessing it would #
+#                      raise page fault exception of the corresponding access type.             #
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                      # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT
+    
+main:
+    la a1,pgtb_l0                                                   # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_V )                                           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,code                                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                    # generrates the VA for label code
+    mv s5,a0                                                        # move VA to s5
+    mv s10,s5                                                       # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1
+
+    la a1,arr                                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                                    # generrates the VA for label arr
+    mv s6,a0                                                        # move VA to s6
+    CLEAR_REG(a2)                                                   # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                          # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                                 # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                            # changes mode M to U and set the MEPC value to s5
+
+code:
+    li t0,ALL_F_S                            
+    j exit
+
+ABit_trap_handler                                                    # trap handler      
+COREV_VERIF_EXIT_LOGIC                                               # exit logic 
+RVTEST_DATA_SECTION                                                  # data section                                                         
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage01.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage01.S
@@ -1,0 +1,59 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read acces in Supervisor mode for Level1                          #
+#                                                                                               #
+# Description:       Read access to the PTE should raise load page fault for read access        #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                       # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                        # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT   
+main:     
+
+    la a1,code                                        # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                      # generrates the VA for label code
+    mv s5,a0                                          # move VA to s5
+    mv s10,s5                                         # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                     # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )     # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)            # setup the PTE for level1
+
+    la a1,arr                                         # loads the address of label arr
+    CLEAR_REG(a2)                                     # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                      # generrates the VA for label arr
+    mv s6,a0                                          # move VA to s6
+    CLEAR_REG(a2)                                     # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)            # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                   # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                              # changes mode M to U and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+
+end:
+
+ABit_trap_handler                                     # trap handler      
+COREV_VERIF_EXIT_LOGIC                                # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                        # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage02.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage02.S
@@ -1,0 +1,59 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the write acces in Supervisor mode for Level1                         #
+#                                                                                               #
+# Description:       Write access to the PTE should raise store/AMO page fault                  #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                               # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT   
+main:     
+
+    la a1,code                                                # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                              # generrates the VA for label code
+    mv s5,a0                                                  # move VA to s5
+    mv s10,s5                                                 # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )             # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1
+
+    la a1,arr                                                 # loads the address of label arr
+    CLEAR_REG(a2)                                             # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                              # generrates the VA for label arr
+    mv s6,a0                                                  # move VA to s6
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_W | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                           # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                      # changes mode M to U and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+
+end:
+
+ABit_trap_handler                                             # trap handler      
+COREV_VERIF_EXIT_LOGIC                                        # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                                # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage03.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage03.S
@@ -1,0 +1,59 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute acces in Supervisor mode for Level1                       #
+#                                                                                               #
+# Description:       Execute access to the PTE should raise instruction page fault              #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                               # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT   
+main:     
+
+    la a1,code                                                # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                              # generrates the VA for label code
+    mv s5,a0                                                  # move VA to s5
+    mv s10,s5                                                 # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )             # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1
+
+    la a1,arr                                                 # loads the address of label arr
+    CLEAR_REG(a2)                                             # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                              # generrates the VA for label arr
+    mv s6,a0                                                  # move VA to s6
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_W | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                           # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                      # changes mode M to U and set the MEPC value to s5
+    .align 16                                                 # to make the ppn[0] of code misalligned
+
+code:
+    li t1, ALL_F_S                                            # test the Execute Acces in Supervisor mode for Level1 PTE 
+
+end:
+
+ABit_trap_handler                                             # trap handler      
+COREV_VERIF_EXIT_LOGIC                                        # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                                # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage04.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage04.S
@@ -1,0 +1,59 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read acces in User mode for Level1                                #
+#                                                                                               #
+# Description:       Read access to the PTE should raise load page fault for read access        #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                               # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                # set mtvec for trap                         
+    li s11, LOAD_PAGE_FAULT   
+main:     
+
+    la a1,code                                                # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                              # generrates the VA for label code
+    mv s5,a0                                                  # move VA to s5
+    mv s10,s5                                                 # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )     # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1
+
+    la a1,arr                                                 # loads the address of label arr
+    CLEAR_REG(a2)                                             # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                              # generrates the VA for label arr
+    mv s6,a0                                                  # move VA to s6
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                           # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                      # changes mode M to U and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                            
+
+end:
+
+ABit_trap_handler                                             # trap handler      
+COREV_VERIF_EXIT_LOGIC                                        # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                                # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage05.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage05.S
@@ -1,0 +1,60 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the write acces in User mode for Level1                               #
+#                                                                                               #
+# Description:       Write access to the PTE should raise store/AMO page fault                  #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                               # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                # set mtvec for trap                         
+    li s11, STORE_AMO_PAGE_FAULT   
+main:     
+
+    la a1,code                                                # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                              # generrates the VA for label code
+    mv s5,a0                                                  # move VA to s5
+    mv s10,s5                                                 # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )     # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1
+
+    la a1,arr                                                 # loads the address of label arr
+    CLEAR_REG(a2)                                             # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                              # generrates the VA for label arr
+    mv s6,a0                                                  # move VA to s6
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                           # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                      # changes mode M to U and set the MEPC value to s5
+
+code:
+    sw t1,0(s6)                            
+
+end:
+
+ABit_trap_handler                                             # trap handler      
+COREV_VERIF_EXIT_LOGIC                                        # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                                # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+
+

--- a/cva6/tests/custom/sv32/Misaligned_Superpage06.S
+++ b/cva6/tests/custom/sv32/Misaligned_Superpage06.S
@@ -1,0 +1,58 @@
+
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute acces in User mode for Level1                             #
+#                                                                                               #
+# Description:       Execute access to the PTE should raise store/AMO page fault                #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         Misaligned Superpage                                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE at level1 is leaf PTE (superpage) and its pte.ppn[0]=0, then it   # 
+#                      is a misaligned superpage and accessing that PTE would raise page fault  # 
+#                      exception of the corresponding access type.                              #   
+#                                                                                               #
+#################################################################################################   
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    ALL_MEM_PMP                                               # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                # set mtvec for trap                         
+    li s11, INSTRUCTION_PAGE_FAULT   
+main:     
+
+    la a1,code                                                # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                              # generrates the VA for label code
+    mv s5,a0                                                  # move VA to s5
+    mv s10,s5                                                 # move the VA of label code to s10 that will be compared later
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )     # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1
+
+    la a1,arr                                                 # loads the address of label arr
+    CLEAR_REG(a2)                                             # clear the reg a2
+    GEN_VA(a1, a0, 0x200, 0x000)                              # generrates the VA for label arr
+    mv s6,a0                                                  # move VA to s6
+    CLEAR_REG(a2)                                             # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_R | PTE_V)       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                    # setup the PTE for level1   
+
+    SATP_SETUP_SV32                                           # set the SATP for virtualization
+    CHANGE_T0_U_MODE(s5)                                      # changes mode M to U and set the MEPC value to s5
+    .align 16                                                 # to make the ppn[0] of code misalligned
+
+code:
+    li t1, ALL_F_S                                            # test the Execute Acces in Supervisor mode for Level1 PTE 
+
+end:
+
+ABit_trap_handler                                             # trap handler      
+COREV_VERIF_EXIT_LOGIC                                        # exit logic 
+RVTEST_DATA_SECTION_MISALIGNED                                # ppn[0]!=0 for Misaligned Superpage 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_S_01.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_01.S
@@ -1,0 +1,58 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read Acces in Supervisor mode for Level1 (PTE.r = 1)              #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s10,110
+main: 
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:
+    li t1,ALL_F_S     
+    lw t1,0(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_02.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_02.S
@@ -1,0 +1,62 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level1 (PTE.w = 1)             #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s10,110
+
+main: 
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:             
+    li t1,ALL_F_S                            
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+    # j exit
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_03.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_03.S
@@ -1,0 +1,61 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the execute Acces in Supervisor mode for Level1 (PTE.x = 1)           #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s10,110
+    
+main: 
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:             
+    li t1,ALL_F_S                            
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_04.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_04.S
@@ -1,0 +1,66 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read Acces in Supervisor mode for Level0 (PTE.r = 1)              #      
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap                  
+    li s10,110                                                        
+main: 
+
+    la a1,pgtb_l0                                                       # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_V )                                               # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1
+    
+
+    GEN_VA(a1, a0, 0x100, 0x010)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_R | PTE_V )                       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:
+    li t1,ALL_F_S     
+    lw t1,0(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    j exit
+    
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_05.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_05.S
@@ -1,0 +1,67 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level0 (PTE.w = 1)             #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap                  
+    li s10,110                                                        
+main: 
+
+    la a1,pgtb_l0                                                       # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_V )                                               # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1
+    
+
+    GEN_VA(a1, a0, 0x100, 0x010)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:             
+    li t1,ALL_F_S                            
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+    j exit                                                       
+
+    
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_06.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_06.S
@@ -1,0 +1,70 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the execute Acces in Supervisor mode for Level0 (PTE.x = 1)           #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap                  
+    li s10,110                                                        
+main: 
+
+    la a1,pgtb_l0                                                       # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_V )                                               # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+    
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to s5
+    CLEAR_REG(a2)                                                       # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )       # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1
+    
+
+    GEN_VA(a1, a0, 0x100, 0x010)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to s6
+    CLEAR_REG(a2)                                                       # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_R | PTE_W | PTE_V )               # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # changes mode M to S and set the MEPC value to s5
+
+code:             
+    li t1,ALL_F_S                                                       # test the Execute Acces in Supervisor mode for Level1 PTE 
+    sw t1,4(s6)                                                    
+    lw t2,4(s6)
+    j exit
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_07.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_07.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read Acces in Supervisor mode for Level1 (PTE.r = 0)              #
+#                                                                                               #
+# Description:       Execute access should raise load page fault for read access.               # 
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: When satp.mode=sv32, PTE has (r,w,x) PMP permissions, PTE has            #
+#                      non-reserved RWX encoding, pte.u=0 and pte.v=1, then test the following  #
+#                      in supervisor privilege mode level 1 PTE.                                #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                          # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                           # set mtvec for trap
+    li s11, LOAD_PAGE_FAULT                             
+    
+main: 
+
+    la a1,code                                           # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                         # generrates the VA for label code
+    mv s5,a0                                             # move VA to s5
+    mv s10,s5                                            # loads the VA in s10 which will be compared in trap handler
+    CLEAR_REG(a2)                                        # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )        # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)               # setup the PTE for level1
+    
+    la a1,arr                                            # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                         # generrates the VA for label arr
+    mv s6,a0                                             # move VA to s6
+    CLEAR_REG(a2)                                        # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )        # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)               # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                      # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                 # changes mode M to S and set the MEPC value to s5
+
+code:   
+    lw t1,0(s6)                                          # test the Read Acces in Supervisor mode for Level1 PTE 
+
+ABit_trap_handler                                        # trap handler  
+COREV_VERIF_EXIT_LOGIC                                   # exit logic 
+RVTEST_DATA_SECTION                                      # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_08.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_08.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level1 (PTE.w = 0)             #
+#                                                                                               #
+# Description:       Execute access should raise store/AMO page fault for write access.         #   
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: When satp.mode=sv32, PTE has (r,w,x) PMP permissions, PTE has            #
+#                      non-reserved RWX encoding, pte.u=0 and pte.v=1, then test the following  #
+#                      in supervisor privilege mode level 1 PTE.                                #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                          # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                           # set mtvec for trap
+    li s11, STORE_AMO_PAGE_FAULT                             
+    
+main: 
+
+    la a1,code                                           # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                         # generrates the VA for label code
+    mv s5,a0                                             # move VA to s5
+    mv s10,s5                                            # loads the VA in s10 which will be compared in trap handler
+    CLEAR_REG(a2)                                        # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )        # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)               # setup the PTE for level1
+    
+    la a1,arr                                            # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                         # generrates the VA for label arr
+    mv s6,a0                                             # move VA to s6
+    CLEAR_REG(a2)                                        # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )        # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)               # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                      # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                 # changes mode M to S and set the MEPC value to s5
+
+code:   
+    sw t1,4(s6)                                          # test the Read Acces in Supervisor mode for Level1 PTE 
+
+ABit_trap_handler                                        # trap handler  
+COREV_VERIF_EXIT_LOGIC                                   # exit logic 
+RVTEST_DATA_SECTION                                      # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_09.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_09.S
@@ -1,0 +1,57 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute Acces in Supervisor mode for Level1 (PTE.x = 0)           #
+#                                                                                               #
+# Description:       Execute access should raise instruction  page fault for execute.           #                                  
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: When satp.mode=sv32, PTE has (r,w,x) PMP permissions, PTE has            #
+#                      non-reserved RWX encoding, pte.u=0 and pte.v=1, then test the following  #
+#                      in supervisor privilege mode level 1 PTE.                                #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                             # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                              # set mtvec for trap
+    li s11, INSTRUCTION_PAGE_FAULT                             
+    
+main: 
+
+    la a1,code                                              # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                            # generrates the VA for label code
+    mv s5,a0                                                # move VA to s5
+    mv s10,s5                                               # loads the VA in s10 which will be compared in trap handler
+    CLEAR_REG(a2)                                           # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                  # setup the PTE for level1
+    
+    la a1,arr                                               # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                            # generrates the VA for label arr
+    mv s6,a0                                                # move VA to s6
+    CLEAR_REG(a2)                                           # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                  # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                         # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                    # changes mode M to S and set the MEPC value to s5
+
+code:   
+    sw t1,4(s6)                                             # test the Read Acces in Supervisor mode for Level1 PTE 
+
+ABit_trap_handler                                           # trap handler  
+COREV_VERIF_EXIT_LOGIC                                      # exit logic 
+RVTEST_DATA_SECTION                                         # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_10.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_10.S
@@ -1,0 +1,66 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read Acces in Supervisor mode for Level0 (PTE.r = 0)              #      
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                     # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                      # set mtvec for trap
+    li s11, LOAD_PAGE_FAULT                             
+
+main: 
+
+    la a1,pgtb_l0                                   # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                    # generrates the VA for label code
+    CLEAR_REG(a2)                                   # clear the reg a2   
+    ori a2, a2, ( PTE_V )                           # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)          # setup the PTE for level1
+    
+
+    la a1,code                                      # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                    # generrates the VA for label code
+    mv s5,a0                                        # move VA to s5
+    mv s10,s5                                       # loads the VA in s10 which will be compared in trap handler    
+    CLEAR_REG(a2)                                   # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)          # setup the PTE for level1
+    
+    la a1,arr                                       # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                    # generrates the VA for label arr
+    mv s6,a0                                        # move VA to s6
+    CLEAR_REG(a2)                                   # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_V )   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)          # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                 # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                            # changes mode M to S and set the MEPC value to s5
+
+code:
+    lw t1,0(s6)                                     # test the Read Acces in Supervisor mode for Level1 PTE 
+    j exit
+    
+ABit_trap_handler                                   # trap handler  
+COREV_VERIF_EXIT_LOGIC                              # exit logic 
+RVTEST_DATA_SECTION                                 # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+

--- a/cva6/tests/custom/sv32/RWX_Access_S_11.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_11.S
@@ -1,0 +1,66 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level0 (PTE.w = 0)             #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                            # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                             # set mtvec for trap
+    li s11, STORE_AMO_PAGE_FAULT                             
+
+main: 
+
+    la a1,pgtb_l0                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                           # generrates the VA for label code
+    CLEAR_REG(a2)                                          # clear the reg a2   
+    ori a2, a2, (PTE_V )                                   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                 # setup the PTE for level1
+
+    la a1,code                                             # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                           # generrates the VA for label code
+    mv s5,a0                                               # move VA to s5
+    mv s10,s5                                              # loads the VA in s10 which will be compared in trap handler    
+    CLEAR_REG(a2)                                          # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_R | PTE_V )  # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                 # setup the PTE for level1
+    
+    la a1,arr                                              # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                           # generrates the VA for label arr
+    mv s6,a0                                               # move VA to s6
+    CLEAR_REG(a2)                                          # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_X | PTE_R | PTE_V )  # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                 # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                        # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                   # changes mode M to S and set the MEPC value to s5
+
+code:                                    
+    sw t1,4(s6)                                             # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+    j exit                                                       
+
+ABit_trap_handler                                           # trap handler  
+COREV_VERIF_EXIT_LOGIC                                      # exit logic 
+RVTEST_DATA_SECTION                                         # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_S_12.S
+++ b/cva6/tests/custom/sv32/RWX_Access_S_12.S
@@ -1,0 +1,66 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute Acces in Supervisor mode for Level0 (PTE.x = 0)           #
+#                                                                                               #
+# Description:       RWX access should be successful if the corresponding permissions           #
+#                    are granted in the PTE. Check that load, store and execute works           #
+#                    without any page fault.                                                    #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on S-mode pages in S-mode                                     #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to supervisor mode i.e. its U permission bit is clear     #
+#                      (pte.u = 0),then accessing that PTE in supervisor mode should be         #
+#                      successful if the corresponding (r,w,x) permission of PTE is granted.    #   
+#                      Otherwise raise a page fault exception of the corresponding access type  #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                            # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                             # set mtvec for trap
+    li s11, INSTRUCTION_PAGE_FAULT                             
+
+main: 
+
+    la a1,pgtb_l0                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                           # generrates the VA for label code
+    CLEAR_REG(a2)                                          # clear the reg a2   
+    ori a2, a2, (PTE_V )                                   # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                 # setup the PTE for level1
+
+    la a1,code                                             # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                           # generrates the VA for label code
+    mv s5,a0                                               # move VA to s5
+    mv s10,s5                                              # loads the VA in s10 which will be compared in trap handler    
+    CLEAR_REG(a2)                                          # clear the reg a2   
+    ori a2, a2, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )  # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                 # setup the PTE for level1
+    
+    la a1,arr                                              # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                           # generrates the VA for label arr
+    mv s6,a0                                               # move VA to s6
+    CLEAR_REG(a2)                                          # clear the reg a2 
+    ori a2, a2, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )  # sets the permission bits                  
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                 # setup the PTE for level1   
+     
+    SATP_SETUP_SV32                                        # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                   # changes mode M to S and set the MEPC value to s5
+
+code:             
+    sw t1,4(s6)                                             # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+    j exit                                                       
+
+ABit_trap_handler                                           # trap handler  
+COREV_VERIF_EXIT_LOGIC                                      # exit logic 
+RVTEST_DATA_SECTION                                         # data section                                 
+            
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_U_01.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_01.S
@@ -1,0 +1,63 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read acces in Supervisor mode for Level1 such that                #
+#                    (PTE.x = 1, PTE.r = 1, PTE.u=1 and mstatus.SUM=1)                          #
+#                                                                                               #
+# Description:       Read access to the PTE should be successful. So, the load works without    #
+#                    page fault and expected data is loaded from the memory                     #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                 # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                  # set mtvec for trap
+    li s11, ILLEGAL_INSTRUCTION                             
+main:
+
+    la a1,code                                                  # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code
+    mv s5,a0                                                    # move VA to t2         
+    mv s10,s5                                                   # move the VA of label code to s10 
+    CLEAR_REG(a2)                                               # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_V )                # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                      # setup the PTE for level1
+                        
+    la a1,arr                                                   # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                # generrates the VA for label arr
+    mv s6,a0                                                    # move VA to t3
+    CLEAR_REG(a2)                                               # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_U | PTE_R | PTE_V) # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                      # setup the PTE for level1   
+                           
+    SATP_SETUP_SV32                                             # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                        # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    li t1,ALL_F_S                            
+    lw t1,0(s6)                                                 # test the Read Acces in Supervisor mode for Level1 PTE 
+    j exit
+
+ABit_trap_handler                                               # trap handler  
+COREV_VERIF_EXIT_LOGIC                                          # exit logic 
+RVTEST_DATA_SECTION                                             # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_U_02.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_02.S
@@ -1,0 +1,64 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level1 such that               #
+#                    (PTE.w = 1, PTE.r = 1, PTE.u=1 and mstatus.SUM=1)                          #
+#                                                                                               #
+# Description:       Write access to the PTE should be successful. So, store works without page #
+#                    fault and expected data is stored to the memory.                           #
+#                                                                                               #         
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s11, ILLEGAL_INSTRUCTION                             
+main:
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to t2         
+    mv s10,s5                                                           # move the VA of label code to s10 
+    CLEAR_REG(a2)                                                       # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_V )                        # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+                        
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to t3
+    CLEAR_REG(a2)                                                       # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_U | PTE_W | PTE_R | PTE_V) # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1   
+                           
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    li t1,ALL_F_S                            
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+    j exit
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+
+
+

--- a/cva6/tests/custom/sv32/RWX_Access_U_03.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_03.S
@@ -1,0 +1,58 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute Acces in Supervisor mode for Level1 such that             #
+#                    (PTE.x = 1, PTE.v = 1, PTE.u=1 and mstatus.SUM=1 )                         #
+#                                                                                               #
+# Description:       Execute access should raise instruction page fault.                        #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s11, INSTRUCTION_PAGE_FAULT                             
+main:
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to t2         
+    mv s10,s5                                                           # move the VA of label code to s10 
+    CLEAR_REG(a2)                                                       # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1
+                        
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x200, 0x000)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to t3
+    CLEAR_REG(a2)                                                       # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V)         # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                              # setup the PTE for level1   
+                           
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    CHANGE_T0_S_MODE(s5)                                                # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    li t1,ALL_F_S                            
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_U_04.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_04.S
@@ -1,0 +1,65 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Read acces in Supervisor mode for Level0 such that                #
+#                    (PTE.x = 1, PTE.r = 1, PTE.u=1 and mstatus.SUM=1)                          #
+#                                                                                               #
+# Description:       Read access to the PTE should be successful. So, the load works without    #
+#                    page fault and expected data is loaded from the memory                     #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                 # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                  # set mtvec for trap
+    li s11, LOAD_PAGE_FAULT                             
+main:
+
+    la a1,pgtb_l0                                               # loads the  base address of pgtb0
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code                   
+    ori a2, a2, ( PTE_V )                                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, 1)                           # setup the PTE for level1
+
+    la a1,code                                                  # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code
+    mv s5,a0                                                    # move VA to t2         
+    mv s10,s5                                                   # move the VA of label code to s10 
+    CLEAR_REG(a2)                                               # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_V )                # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                      # setup the PTE for level1
+                        
+    la a1,arr                                                   # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                                # generrates the VA for label arr
+    mv s6,a0                                                    # move VA to t3
+    CLEAR_REG(a2)                                               # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_R | PTE_V) # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                      # setup the PTE for level1   
+                           
+    SATP_SETUP_SV32                                             # set the SATP for virtualization
+    # li s7, MSTATUS_SUM
+    # WRITE_CSR(mstatus,s7)                                     # set the mstatus.SUM = 1 
+    CHANGE_T0_S_MODE(s5)                                        # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    lw t1,0(s6)                                                 # test the Read Acces in Supervisor mode for Level1 PTE 
+    j exit
+
+ABit_trap_handler                                               # trap handler  
+COREV_VERIF_EXIT_LOGIC                                          # exit logic 
+RVTEST_DATA_SECTION                                             # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_U_05.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_05.S
@@ -1,0 +1,65 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Write Acces in Supervisor mode for Level0 such that               #
+#                    (PTE.w = 1, PTE.r = 1, PTE.u=1 and mstatus.SUM=1)                          #
+#                                                                                               #
+# Description:       Write access to the PTE should be successful. So, store works without page #
+#                    fault and expected data is stored to the memory.                           #
+#                                                                                               #         
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                 # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                  # set mtvec for trap
+    li s11, LOAD_PAGE_FAULT                             
+main:
+
+    la a1,pgtb_l0                                               # loads the  base address of pgtb0
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code                   
+    ori a2, a2, ( PTE_V )                                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, 1)                           # setup the PTE for level1
+
+    la a1,code                                                  # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code
+    mv s5,a0                                                    # move VA to t2         
+    mv s10,s5                                                   # move the VA of label code to s10 
+    CLEAR_REG(a2)                                               # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_X | PTE_V )                # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                      # setup the PTE for level1
+                        
+    la a1,arr                                                   # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                                # generrates the VA for label arr
+    mv s6,a0                                                    # move VA to t3
+    CLEAR_REG(a2)                                               # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V) # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                      # setup the PTE for level1   
+                           
+    # SATP_SETUP_SV32                                           # set the SATP for virtualization
+    # li s7, MSTATUS_SUM
+    WRITE_CSR(mstatus,s7)                                       # set the mstatus.SUM = 1 
+    CHANGE_T0_S_MODE(s5)                                        # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    sw t1,0(s6)                                                 # test the Read Acces in Supervisor mode for Level1 PTE
+    j exit
+
+ABit_trap_handler                                               # trap handler  
+COREV_VERIF_EXIT_LOGIC                                          # exit logic 
+RVTEST_DATA_SECTION                                             # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/RWX_Access_U_06.S
+++ b/cva6/tests/custom/sv32/RWX_Access_U_06.S
@@ -1,0 +1,69 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal: Test the Execute Acces in Supervisor mode for level0 such that             #
+#                    (PTE.x = 1, PTE.v = 1, PTE.u=1 and mstatus.SUM=1 )                         #
+#                                                                                               #
+# Description:       Execute access should raise instruction page fault.                        #
+#                                                                                               #
+#################################################################################################
+#                                                                                               #
+# Sub Feature:         RWX access on U-mode pages in S-mode with s/mstatus.SUM set              #                
+#                                                                                               #   
+# Feature Discription: If PTE belongs to user mode i.e. its U permission bit is set (pte.u = 1) #
+#                      and m/sstatus.SUM = 1, then RW access to that PTE in supervisor mode     #
+#                      would be successful but eXecute access would raise instruction page      #
+#                      fault exception in s-mode.                                               #   
+#                                                                                               #
+#################################################################################################   
+
+
+#include "macros.h"
+
+.text
+.global _start
+_start:
+
+    PMP_ALL_MEM                                                         # set the PMP permissions
+    TRAP_HANDLER(trap_handler)                                          # set mtvec for trap
+    li s11, INSTRUCTION_PAGE_FAULT                             
+main:
+
+    la a1,pgtb_l0                                               # loads the  base address of pgtb0
+    GEN_VA(a1, a0, 0x100, 0x000)                                # generrates the VA for label code                 
+    ori a2, a2, ( PTE_V )        # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                           # setup the PTE for level0
+
+    la a1,code                                                          # loads the address of label code
+    GEN_VA(a1, a0, 0x100, 0x000)                                        # generrates the VA for label code
+    mv s5,a0                                                            # move VA to t2         
+    mv s10,s5                                                           # move the VA of label code to s10 
+    CLEAR_REG(a2)                                                       # clear the reg a2                   
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_X | PTE_V )                # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1
+                        
+    la a1,arr                                                           # loads the address of label arr
+    GEN_VA(a1, a0, 0x100, 0x010)                                        # generrates the VA for label arr
+    mv s6,a0                                                            # move VA to t3
+    CLEAR_REG(a2)                                                       # clear the reg a2    
+    ori a2, a2, (PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V)         # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                              # setup the PTE for level1   
+                           
+    SATP_SETUP_SV32                                                     # set the SATP for virtualization
+    # li s7, MSTATUS_SUM
+    # WRITE_CSR(mstatus,s7)                                             # set the mstatus.SUM = 1     
+    CHANGE_T0_S_MODE(s5)                                                # change mode M to S and set the MEPC value to t2       
+         
+code:             
+    sw t1,4(s6)                                                         # test the Read Acces in Supervisor mode for Level1 PTE 
+    lw t2,4(s6)
+
+ABit_trap_handler                                                       # trap handler  
+COREV_VERIF_EXIT_LOGIC                                                  # exit logic 
+RVTEST_DATA_SECTION                                                     # data section                                 
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+
+
+
+

--- a/cva6/tests/custom/sv32/macros.h
+++ b/cva6/tests/custom/sv32/macros.h
@@ -1,0 +1,1818 @@
+#include "encoding.h"
+
+#define SATP_SV32_MODE_VAL 0x01
+
+#define SREG sw
+#define LREG lw
+#define MRET mret
+#define S_MODE 0x02
+#define U_MODE 0x00
+
+#define ENABLE_READ_CHECK 0x01
+#define DISABLE_READ_CHECK 0x00
+#define ENABLE_WRITE_CHECK 0x01
+#define DISABLE_WRITE_CHECK 0x00
+#define ENABLE_EXECUTE_CHECK 0x01
+#define DISBALE_EXECUTE_CHECK 0x00
+
+#define LEVEL0 0x00
+#define LEVEL1 0x01
+
+#define ACCESS_BIT_TEST 0x01
+#define VM_PMP_TEST     0x02
+#define VM_MXR_UNSET_TEST 0x03
+#define VM_SUM_UNSET_TEST 0x04
+#define VM_SATP_SV32_MODE_TEST 0x05
+
+#define REG_CLEAR 0x1
+#define NO_REG_CLEAR 0x0
+
+#define ALL_F_S 0xFFFFFFFF
+#define LHW_F_S 0x0000FFFF
+#define UHW_F_S 0xFFFF0000
+#define B1_F_S 0x000000FF
+#define B2_F_S 0x0000FF00
+#define B3_F_S 0x00FF0000
+#define B4_F_S 0xFF000000
+
+#define PMPADDR0 0x0
+#define PMPADDR1 0x1
+#define PMPADDR2 0x2
+#define PMPADDR3 0x3
+
+#define PMPADDR0 0x0
+#define PMPADDR1 0x1
+#define PMPADDR2 0x2
+#define PMPADDR3 0x3
+
+#define PMPCFG_0_SHIFT 0x00
+#define PMPCFG_1_SHIFT 0x08
+#define PMPCFG_2_SHIFT 0x10
+#define PMPCFG_3_SHIFT 0x18
+
+#define NAPOT_RANGE_8B 0x0
+#define NAPOT_RANGE_16B 0x01
+#define NAPOT_RANGE_32B 0x03
+
+#define PTE_OFFSET_SHIFT 12
+
+#define INSTRUCTION_ADDRESS_MISALIGNED 0
+#define INSTRUCTION_ACCESS_FAULT 1
+#define ILLEGAL_INSTRUCTION 2
+#define BREAKPOINT 3
+#define LOAD_ADDRESS_MISALIGNED 4
+#define LOAD_ACCESS_FAULT 5
+#define STORE_AMO_ADDRESS_MISALIGNED 6
+#define STORE_AMO_ACCESS_FAULT 7
+#define ENVIRONMENT_CALL_FROM_U_MODE 8
+#define ENVIRONMENT_CALL_FROM_S_MODE 9
+#define ENVIRONMENT_CALL_FROM_M_MODE 11
+#define INSTRUCTION_PAGE_FAULT 12
+#define LOAD_PAGE_FAULT 13
+#define STORE_AMO_PAGE_FAULT 15
+
+#define OP_READ 0x0
+#define OP_WRITE 0x1
+#define OP_EXECUTE 0x01
+
+#define ASID_IMPLE_CVA6 0x00400000
+#define EXPECTED_ASID 0x00400000
+
+#define WRITE_MEPC(_TR1, LABEL)                                    ;\
+    la _TR1, LABEL                                                 ;\
+    WRITE_CSR(mepc, _TR1)                                          ;
+
+#define SET_RWX_PERMISSION(REG, ZERO)                              ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        SET_PTE_R(REG, REG_CLEAR)                                      ;\
+    .else                                                          ;\
+        SET_PTE_R(REG, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    SET_PTE_W(REG, NO_REG_CLEAR)                                       ;\
+    SET_PTE_X(REG, NO_REG_CLEAR)                                       ;
+
+#define SET_RWXV_BITS(REG, ZERO)                                   ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        SET_PTE_R(REG, REG_CLEAR)                                      ;\
+    .else                                                          ;\
+        SET_PTE_R(REG, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    SET_PTE_W(REG, NO_REG_CLEAR)                                       ;\
+    SET_PTE_X(REG, NO_REG_CLEAR)                                       ;\
+    SET_PTE_V(REG, NO_REG_CLEAR)                                       ;
+
+#define SET_RW_BITS(REG, ZERO)                                     ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        SET_PTE_R(REG, REG_CLEAR)                                      ;\
+    .else                                                          ;\
+        SET_PTE_R(REG, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    SET_PTE_W(REG, NO_REG_CLEAR)                                       ;\
+
+#define SET_RV_BITS(REG, ZERO)                                     ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        SET_PTE_R(REG, REG_CLEAR)                                      ;\
+    .else                                                          ;\
+        SET_PTE_R(REG, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    SET_PTE_V(REG, NO_REG_CLEAR)                                       ;\
+
+#define SET_WV_BITS(REG, ZERO)                                     ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        SET_PTE_W(REG, REG_CLEAR)                                      ;\
+    .else                                                          ;\
+        SET_PTE_W(REG, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    SET_PTE_V(REG, NO_REG_CLEAR)                                       ;\
+
+#define SET_PTE_R(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_R                                            ;
+
+#define SET_PTE_W(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_W                                            ;
+
+#define SET_PTE_X(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_X                                            ;
+
+#define SET_PTE_U(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_U                                            ;
+
+#define SET_PTE_G(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_G                                            ;
+
+#define SET_PTE_A(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_A                                            ;
+
+#define SET_PTE_D(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                 ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_D                                            ;
+
+#define SET_PTE_V(REG, ZERO)                                       ;\
+    .if(ZERO==REG_CLEAR)                                               ;\
+        CLEAR_REG(REG)                                                  ;\
+    .endif                                                         ;\
+    ori REG, REG, PTE_V                                            ;
+
+#define CHECK_SV32_MODE(REG)                                       ;\
+    GET_SATP_MODE(REG)                                             ;
+
+#define GET_SATP_MODE(DST_REG)                                     ;\
+    READ_CSR(satp, DST_REG)                                        ;\
+    srli DST_REG, DST_REG, 31                                      ;\
+
+#define WRITE_CSR(CSR_REG, SRC_REG)                                ;\
+    csrw CSR_REG, SRC_REG                                          ;
+
+#define CLEAR_CSR(CSR_REG, SRC_REG)                                ;\
+    csrc CSR_REG, SRC_REG                                          ;
+
+#define SET_CSR(CSR_REG, SRC_REG)                                  ;\
+    csrs CSR_REG, SRC_REG                                          ;
+
+#define READ_CSR(CSR_REG, DST_REG)                                 ;\
+    csrr DST_REG, CSR_REG                                          ;
+
+#define PTE(PA, PR)                                                ;\
+    srli     PA, PA, PTE_OFFSET_SHIFT                                            ;\
+    slli     PA, PA, PTE_PPN_SHIFT                                 ;\
+    or       PA, PA, PR                                            ;
+
+#define PTE_SETUP_RV32(PA, PR, TMP, VA, level)                     ;\
+    PTE(PA, PR)                                                    ;\
+    .if (level==1)                                                 ;\
+        la   TMP, pgtb_l1                                          ;\
+        srli VA,  VA, 22                                           ;\
+    .endif                                                         ;\
+    .if (level==0)                                                 ;\
+        la   TMP, pgtb_l0                                          ;\
+        slli VA,  VA, 10                                           ;\
+        srli VA,  VA, 22                                           ;\
+    .endif                                                         ;\
+    slli     VA,  VA,  2                                           ;\
+    add      TMP, TMP, VA                                          ;\
+    SREG     PA,  0(TMP)                                           ;
+
+#define SATP_SETUP_SV32                                            ;\
+    la   t6,   pgtb_l1                                             ;\
+    li   t5,   SATP32_MODE                                         ;\
+    srli t6,   t6, 12                                              ;\
+    or   t6,   t6, t5                                              ;\
+    WRITE_CSR(satp, t6)                                            ;\
+    sfence.vma;
+
+#define EXIT_LOGIC(REG, VAL)                                       ;\
+    SREG VAL, 0(REG)                                               ;
+
+#define GEN_VA(PA, VA, UP_10_BITS, MID_10_BITS)                    ;\
+    slli VA, PA, 20                                                ;\
+    srli VA, VA, 20                                                ;\
+    li   t0, UP_10_BITS                                            ;\
+    slli t0, t0, 22                                                ;\
+    or   VA, VA, t0                                                ;\
+    li   t0, MID_10_BITS                                           ;\
+    slli t0, t0, 12                                                ;\
+    or   VA, VA, t0                                                ;
+
+
+#define CLEAR_ALL_PMPADDR                                          ;\
+    WRITE_CSR(pmpaddr0, x0)                                        ;\
+    WRITE_CSR(pmpaddr1, x0)                                        ;\
+    WRITE_CSR(pmpaddr2, x0)                                        ;\
+    WRITE_CSR(pmpaddr3, x0)                                        ;\
+    WRITE_CSR(pmpaddr4, x0)                                        ;\
+    WRITE_CSR(pmpaddr5, x0)                                        ;\
+    WRITE_CSR(pmpaddr6, x0)                                        ;\
+    WRITE_CSR(pmpaddr7, x0)                                        ;\
+    WRITE_CSR(pmpaddr8, x0)                                        ;\
+    WRITE_CSR(pmpaddr9, x0)                                        ;\
+    WRITE_CSR(pmpaddr10, x0)                                       ;\
+    WRITE_CSR(pmpaddr11, x0)                                       ;\
+    WRITE_CSR(pmpaddr12, x0)                                       ;\
+    WRITE_CSR(pmpaddr13, x0)                                       ;\
+    WRITE_CSR(pmpaddr14, x0)                                       ;\
+    WRITE_CSR(pmpaddr15, x0)                                       ;
+
+#define CLEAR_ALL_PMPCFG                                           ;\
+    WRITE_CSR(pmpcfg0, x0)                                         ;\
+    WRITE_CSR(pmpcfg1, x0)                                         ;\
+    WRITE_CSR(pmpcfg2, x0)                                         ;\
+    WRITE_CSR(pmpcfg3, x0)                                         ;\
+
+
+#define CHANGE_T0_S_MODE(MEPC_ADDR)                                ;\
+    li        t0, MSTATUS_MPP                                      ;\
+    CLEAR_CSR (mstatus, t0)                                        ;\
+    li  t1, MSTATUS_MPP & ( MSTATUS_MPP >> 1)                      ;\
+    SET_CSR   (mstatus,t1)                                         ;\
+    WRITE_CSR (mepc,MEPC_ADDR)                                     ;\
+    mret                                                           ;
+
+#define CHANGE_T0_U_MODE(SEPC_ADDR)                                ;\
+    li        t0, SSTATUS_SPP                                      ;\
+    CLEAR_CSR (sstatus,t0)                                         ;\
+    WRITE_CSR (sepc,SEPC_ADDR)                                     ;\
+    sret                                                           ;
+
+#define LA(reg,val)                                                ;\
+    .option push                                               ;\
+    .option rvc                                                ;\
+    .align UNROLLSZ                                            ;\
+    .option norvc                                              ;\
+    la reg,val                                                 ;\
+    .align UNROLLSZ                                            ;\
+    .option p                                                  ;
+
+#define SET_PMP_R(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_R;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_R;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_R;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_R;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define SET_PMP_W(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_W;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_W;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_W;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_W;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define SET_PMP_X(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_X;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_X;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_X;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_X;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define SET_PMP_RWX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);
+
+#define SET_PMP_RX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);
+
+#define SET_PMP_WX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);
+
+#define SET_PMP_RW(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);
+
+#define SET_PMP_TOR_RWX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);\
+    SET_PMP_TOR(REG, TMP, PMPADDR);
+
+#define SET_PMP_NA4_RWX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);\
+    SET_PMP_NA4(REG, TMP, PMPADDR);
+
+#define SET_PMP_NAPOT_RWX(REG, TMP, PMPADDR);\
+    SET_PMP_X(REG, TMP, PMPADDR);\
+    SET_PMP_R(REG, TMP, PMPADDR);\
+    SET_PMP_W(REG, TMP, PMPADDR);\
+    SET_PMP_NA4(REG, TMP, PMPADDR);
+
+#define SET_PMP_TOR(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_TOR;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_TOR;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_TOR;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_TOR;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define SET_PMP_NA4(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_NA4;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_NA4;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_NA4;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_NA4;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define SET_PMP_NAPOT(REG, TMP, PMPADDR);\
+    .if(PMPADDR == PMPADDR0);\
+        ori REG, REG, PMP_NAPOT;\
+    .endif;\
+    .if(PMPADDR == PMPADDR1);\
+        li TMP, PMP_NAPOT;\
+        slli TMP, TMP, 8;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR2);\
+        li TMP, PMP_NAPOT;\
+        slli TMP, TMP, 16;\
+        or REG, REG, TMP;\
+    .endif;\
+    .if(PMPADDR == PMPADDR3);\
+        li TMP, PMP_NAPOT;\
+        slli TMP, TMP, 24;\
+        or REG, REG, TMP;\
+    .endif;\
+    CLEAR_REG(TMP);
+
+#define CLEAR_REG(REG);\
+    li REG, 0;
+
+#define ALL_MEM_PMP                                                ;\
+    li t2, ALL_F_S                                                      ;\
+    csrw pmpaddr0, t2                                              ;\
+    CLEAR_REG(t2);\
+    SET_PMP_TOR_RWX(t2, t6, 0)                                                    ;\
+    csrw pmpcfg0, t2                                               ;\
+
+#define ABit_trap_handler                                          ;\
+    trap_handler:                                                  ;\
+        li t0,110 ;\
+        beq t0,s10,No_excep ;\
+        csrr  t0,    mcause                                        ;\
+        bne   t0, s11, wrong_excep                           ;\
+        csrr  s11, mepc                                             ;\
+        bne   s10, s11, wrong_excep                                 ;\
+        li    t1,   1                                              ;\
+        beq   t0,   t1, instruction_access_fault                   ;\
+        li    t1,   2                                              ;\
+        beq   t0,   t1, illegal_instruction_fault                  ;\
+        li    t1,   5                                              ;\
+        beq   t0,   t1, load_access_fault                          ;\
+        li    t1,   7                                              ;\
+        beq   t0,   t1, store_access_fault                         ;\
+        li    t1,   12                                             ;\
+        beq   t0,   t1, instruction_page_fault                     ;\
+        li    t1,   13                                             ;\
+        beq   t0,   t1, load_page_fault                            ;\
+        li    t1,   15                                             ;\
+        beq   t0,   t1, store_page_fault                           ;\
+        j     trap_handler_end                                     ;\
+    instruction_access_fault:                                      ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    illegal_instruction_fault:                                     ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    load_access_fault:                                             ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    store_access_fault:                                            ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    instruction_page_fault:                                        ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    load_page_fault:                                               ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    store_page_fault:                                              ;\
+        li x1, 0                                                   ;\
+        la s1, tohost                                              ;\
+        j exit                                                     ;\
+    trap_handler_end:                                              ;\
+        j exit                                                     ;\
+    wrong_excep:;\
+        li x1, 1                                                   ;\
+        la s1, tohost                                              ;\
+        j exit;\
+    No_excep:;\
+        j exit
+
+#define TEST_DIRTY_BIT(MODE, LEVEL, R, W, X)                       ;\
+    li s11, STORE_AMO_PAGE_FAULT                                   ;\
+    li t2, -1                                                      ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F                                                    ;\
+    csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                   ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    SET_PTE_D(a2, REG_CLEAR)                                       ;\
+    SET_PTE_X(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>1)                      ;\
+    .else                                                          ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>2)                      ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+        srli t3, t3, 12                                            ;\
+        slli t3, t3, 12                                            ;\
+        .if(MODE == S_MODE)                                        ;\
+            la s2, test_mepc_S                                     ;\
+        .else                                                      ;\
+            la s2, test_mepc_U                                     ;\
+        .endif                                                     ;\
+        slli s2, s2, 20                                            ;\
+        srli s2, s2, 20                                            ;\
+        or s10, t3, s2                                             ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    lw t1, 0(t4)                                                   ;\
+    test_mepc_S:                                                   ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    lw t1, 0(t4)                                                   ;\
+    test_mepc_U:                                                   ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;
+
+#define TEST_VM_FEATURES(MODE, LEVEL, R, W, X, TEST)               ;\
+    .if(X == 1)                                                    ;\
+        li s11, INSTRUCTION_PAGE_FAULT                              ;\
+    .endif                                                         ;\
+    .if(R == 1)                                                    ;\
+        li s11, LOAD_PAGE_FAULT                                     ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        li s11, STORE_AMO_PAGE_FAULT                                ;\
+    .endif                                                         ;\
+    .if(TEST == VM_PMP_TEST)                                       ;\
+        li t2, 0x80000800                                          ;\
+        srli t2, t2, PMP_SHIFT                                     ;\
+        csrw pmpaddr0, t2                                          ;\
+        la t2, pgtb_l1                                             ;\
+        srli t2, t2, PMP_SHIFT                                     ;\
+        csrw pmpaddr1, t2                                          ;\
+        li t2, 0x84000000                                          ;\
+        srli t2, t2, PMP_SHIFT                                     ;\
+        csrw pmpaddr2, t2                                          ;\
+        la t2, test_seg                                            ;\
+        srli t2, t2, PMP_SHIFT                                     ;\
+        ori t2, t2, NAPOT_RANGE_8B                                 ;\
+        csrw pmpaddr3, t2                                          ;\
+        .if(X == 1)                                                ;\
+        li s11, INSTRUCTION_ACCESS_FAULT                            ;\
+        .endif                                                     ;\
+        .if(R == 1)                                                ;\
+            li s11, LOAD_ACCESS_FAULT                               ;\
+        .endif                                                     ;\
+        .if(W == 1)                                                ;\
+            li s11, STORE_AMO_ACCESS_FAULT                          ;\
+        .endif                                                     ;\
+        CLEAR_REG(t2)                                              ;\
+        .if(X==1)                                                  ;\
+            SET_PMP_RW(t2, t6, PMPADDR0)                           ;\
+            SET_PMP_TOR(t2, t6, PMPADDR0)                          ;\
+            SET_PMP_TOR_RWX(t2, t6, PMPADDR2)                      ;\
+            SET_PMP_NAPOT_RWX(t2, t6, PMPADDR3)                    ;\
+        .endif                                                     ;\
+        .if(R==0)                                                  ;\
+            .if(W==1)                                              ;\
+                SET_PMP_TOR_RWX(t2, t6, PMPADDR0)                  ;\
+                SET_PMP_TOR_RWX(t2, t6, PMPADDR2)                  ;\
+                SET_PMP_RX(t2, t6, PMPADDR3)                       ;\
+                SET_PMP_NAPOT(t2, t6, PMPADDR3)                    ;\
+            .endif                                                 ;\
+        .endif                                                     ;\
+        .if(R==1)                                                  ;\
+            .if(W==0)                                              ;\
+                SET_PMP_TOR_RWX(t2, t6, PMPADDR0)                  ;\
+                SET_PMP_TOR_RWX(t2, t6, PMPADDR2)                  ;\
+                SET_PMP_WX(t2, t6, PMPADDR3)                       ;\
+                SET_PMP_NAPOT(t2, t6, PMPADDR3)                    ;\
+            .endif                                                 ;\
+        .endif                                                     ;\
+        csrw pmpcfg0, t2                                           ;\
+    .else                                                          ;\
+        ALL_MEM_PMP                                                ;\
+    .endif                                                         ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                   ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    SET_PTE_D(a2, REG_CLEAR)                                       ;\
+    .if(TEST == ACCESS_BIT_TEST)                                   ;\
+        .if(X != 1)                                                ;\
+            SET_PTE_A(a2, NO_REG_CLEAR)                            ;\
+        .endif                                                     ;\
+    .else                                                          ;\
+        SET_PTE_A(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    SET_RWXV_BITS(a2, NO_REG_CLEAR)                                ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(TEST == VM_SUM_UNSET_TEST)                                 ;\
+        .if(X==1)                                                  ;\
+            SET_PTE_U(a2, NO_REG_CLEAR)                            ;\
+        .endif                                                     ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    li a2, 0                                                       ;\
+    .if(TEST != VM_MXR_UNSET_TEST)                                 ;\
+        SET_PTE_R(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    .if(TEST != ACCESS_BIT_TEST)                                   ;\
+        SET_PTE_A(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .elseif(TEST == VM_SUM_UNSET_TEST)                             ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, MSTATUS_MPP                                             ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2,  MSTATUS_MPP & (MSTATUS_MPP >> 1)                   ;\
+    .else                                                          ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP >> 2)                    ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    mv s10, t3;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    li t1, 0x45                                                    ;\
+    .if(TEST != VM_MXR_UNSET_TEST)                                 ;\
+        la s10, test_mepc_S;\
+        test_mepc_S:                                                   ;\
+        .if(R == 1)                                                ;\
+            lw t1, 0(t4)                                           ;\
+        .endif                                                     ;\
+        .if(W == 1)                                                ;\
+            sw t1, 0(t4)                                           ;\
+        .endif                                                     ;\
+    .else                                                          ;\
+        li s11, LOAD_PAGE_FAULT                                     ;\
+        la s10, test_mepc_S_MXR;\
+        test_mepc_S_MXR:;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    li x1, 1                                                       ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    li t1, 0x45                                                    ;\
+    .if(TEST != VM_MXR_UNSET_TEST)                                 ;\
+        la s10, test_mepc_U;\
+        test_mepc_U:                                                   ;\
+        .if(R == 1)                                                ;\
+            lw t1, 0(t4)                                           ;\
+        .endif                                                     ;\
+        .if(W == 1)                                                ;\
+            sw t1, 0(t4)                                           ;\
+        .endif                                                     ;\
+    .else                                                          ;\
+        la s10, test_mepc_MXR_U;\
+        li s11, LOAD_PAGE_FAULT                                     ;\
+        test_mepc_MXR_U:                                                   ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    li x1, 1                                                       ;\
+    j exit                            ;
+
+ #define PMP_ALL_MEM               ;\
+    li t2, -1		               ;\
+    WRITE_CSR (pmpaddr0, t2)       ;\
+    li t2, 0x0F		               ;\
+    WRITE_CSR (pmpcfg0, t2)        ;
+
+#define TEST_UBIT_UNSET(MODE, LEVEL, R, W, X, A)                ;\
+    li t2, -1		                                               ;\
+	csrw pmpaddr0, t2                                              ;\
+	li t2, 0x0F		                                               ;\
+	csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23;\
+    la t1, test_seg;\
+    sw t2, 0(t1);\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                       ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, REG_CLEAR)                                       ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    .if(A == 1)                                                    ;\
+        SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                       ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2,  0x00800                                            ;\
+    .else                                                          ;\
+        li t2, 0x00000                                             ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    li t1, 0x45                                                    ;\
+    .if(R == 1)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+        li x1, 1                                                   ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    li t1, 0x45                                                    ;\
+    .if(R == 1)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+        li x1, 1                                                   ;\
+    j exit     ;
+
+#define TEST_UBIT_SET(MODE, LEVEL, R, W, X, A)                     ;\
+    li t2, -1		                                               ;\
+	csrw pmpaddr0, t2                                              ;\
+	li t2, 0x0F		                                               ;\
+	csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23;\
+    la t1, test_seg;\
+    sw t2, 0(t1);\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                       ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_U(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, REG_CLEAR)                                       ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    .if(A == 1)                                                    ;\
+        SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    .endif                                                         ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_U(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                       ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                        ;\
+    SET_PTE_U(a2, NO_REG_CLEAR)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2,  0x00800                                            ;\
+    .else                                                          ;\
+        li t2, 0x00000                                             ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    MRET                                                           ;\
+    supervisor_code:;\
+    li t1, 0x45                                                    ;\
+    .if(R == 1)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    li t1, 0x45                                                    ;\
+    .if(R == 1)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit     ;
+
+    #define TRAP_HANDLER( TRAP )                                   ;\
+    la t1, TRAP                                                    ;\
+    WRITE_CSR( mtvec,t1 )                                          ;
+
+    #define RVTEST_DATA_SECTION                                    ;\
+    .data                                                          ;\
+    arr:                                                           ;\
+        .word 0x23                                                 ;\
+    .align 12                                                      ;\
+    pgtb_l1:                                                       ;\
+        .zero 4096                                                 ;\
+    pgtb_l0:                                                       ;\
+        .zero 4096                                                 ;
+#define TEST_Nonleaf_PTE(MODE, LEVEL, R, W, X,XS, op)              ;\
+    .if(op == 0)                                                   ;\
+        li s11, LOAD_PAGE_FAULT                                     ;\
+    .endif                                                         ;\
+    .if(op == 1)                                                   ;\
+        li s11, STORE_AMO_PAGE_FAULT                                ;\
+    .endif                                                         ;\
+    .if(XS == 0)                                                   ;\
+        li s11, INSTRUCTION_PAGE_FAULT                              ;\
+    .endif                                                         ;\
+    li t2, -1                                                      ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F                                                    ;\
+    csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                   ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, REG_CLEAR)                                       ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    .if (XS == OP_EXECUTE)                                         ;\
+       SET_PTE_X(a2, NO_REG_CLEAR)                                 ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    SET_PTE_A(a2, REG_CLEAR)                                       ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, MSTATUS_MPP                                             ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>1)                      ;\
+    .else                                                          ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>2)                      ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    mv s10,t3                                                      ;\
+    .if(XS == 1)                                                   ;\
+        srli t3, t3, 12                                            ;\
+        slli t3, t3, 12                                            ;\
+        .if(MODE == S_MODE)                                        ;\
+            la s2, test_mepc_S                                     ;\
+        .else                                                      ;\
+            la s2, test_mepc_U                                     ;\
+        .endif                                                     ;\
+        slli s2, s2, 20                                            ;\
+        srli s2, s2, 20                                            ;\
+        or s10, t3, s2                                              ;\
+    .endif                                                         ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    test_mepc_S:                                                   ;\
+    .if (op==OP_READ)                                              ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if (op==OP_WRITE)                                             ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    test_mepc_U:                                                   ;\
+    .if (op==0)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if (op==0x01)                                                 ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;
+
+#define TEST_Reserved_RWX(MODE, LEVEL, R, W, X,XS, op)             ;\
+    .if(op == 0)                                                   ;\
+        li s11, LOAD_PAGE_FAULT                                     ;\
+    .endif                                                         ;\
+    .if(op == 1)                                                   ;\
+        li s11, STORE_AMO_PAGE_FAULT                                ;\
+    .endif                                                         ;\
+    .if(XS == 0)                                                   ;\
+        li s11, INSTRUCTION_PAGE_FAULT                              ;\
+    .endif                                                         ;\
+    li t2, -1                                                      ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F                                                    ;\
+    csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                   ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    .if (XS == 1)                                                  ;\
+       SET_PTE_X(a2, NO_REG_CLEAR)                                 ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    SET_PTE_A(a2, REG_CLEAR)                                       ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>1)                      ;\
+    .else                                                          ;\
+        li t2, MSTATUS_MPP & (MSTATUS_MPP>>2)                      ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    mv s10, t3                                                     ;\
+    .if(XS == 1)                                                   ;\
+        srli t3, t3, 12                                            ;\
+        slli t3, t3, 12                                            ;\
+        .if(MODE == S_MODE)                                        ;\
+            la s2, test_mepc_S                                     ;\
+        .else                                                      ;\
+            la s2, test_mepc_U                                     ;\
+        .endif                                                     ;\
+        slli s2, s2, 20                                            ;\
+        srli s2, s2, 20                                            ;\
+        or s10, t3, s2                                              ;\
+    .endif                                                         ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    test_mepc_S:                                                   ;\
+    .if (op==0)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if (op==0x01)                                                 ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    test_mepc_U:                                                   ;\
+    .if (op==0)                                                    ;\
+        lw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if (op==0x01)                                                 ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;
+
+#define TEST_MXR_SET(MODE, LEVEL, R, W, X)                  ;\
+    li t2, -1		                                               ;\
+	csrw pmpaddr0, t2                                              ;\
+	li t2, 0x0F		                                               ;\
+	csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                       ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+        SET_PTE_X(a2, REG_CLEAR)                                   ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, REG_CLEAR)                                   ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    SET_PTE_A(a2, REG_CLEAR)                                       ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_X(a2, NO_REG_CLEAR)                                    ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2, MSTATUS_MXR | (MSTATUS_MPP & (MSTATUS_MPP>>1))        ;\
+    .else                                                          ;\
+        li t2, MSTATUS_MXR|(MSTATUS_MPP & (MSTATUS_MPP>>2))         ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    lw t1, 0(t4)                                                   ;\
+    li s11, 110                                                    ;\
+    mret                                                           ;\
+    user_code:                                                     ;\
+    lw t1, 0(t4)                                                   ;\
+    li s11, 110                                                    ;\
+    mret                                                           ;
+
+#define TEST_MSTATUS_TVM_SATP(MODE, LEVEL, R, W, X,op)             ;\
+    li s11, ILLEGAL_INSTRUCTION                                    ;\
+    li t2, -1                                                      ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F                                                    ;\
+    csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23                                                    ;\
+    la t1, test_seg                                                ;\
+    sw t2, 0(t1)                                                   ;\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, REG_CLEAR)                                   ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    SET_PTE_X(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_W(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_R(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, test_seg                                                ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    SET_PTE_A(a2, REG_CLEAR)                                       ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_V(a2, NO_REG_CLEAR)                                    ;\
+    .if(R == 1)                                                    ;\
+        SET_PTE_R(a2, REG_CLEAR)                                   ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        SET_PTE_W(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, REG_CLEAR)                                   ;\
+    SET_PTE_A(a2, NO_REG_CLEAR)                                    ;\
+    SET_PTE_D(a2, NO_REG_CLEAR)                                    ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_REG_CLEAR)                                ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2, MSTATUS_TVM |(MSTATUS_MPP & (MSTATUS_MPP>>1))       ;\
+    .else                                                          ;\
+        li t2, MSTATUS_TVM | (MSTATUS_MPP & (MSTATUS_MPP>>2))      ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+    mv s10, t3                                                     ;\
+    .if(XS == 1)                                                   ;\
+        srli t3, t3, 12                                            ;\
+        slli t3, t3, 12                                            ;\
+        .if(MODE == S_MODE)                                        ;\
+            la s2, test_mepc_S                                     ;\
+        .else                                                      ;\
+            la s2, test_mepc_U                                     ;\
+        .endif                                                     ;\
+        slli s2, s2, 20                                            ;\
+        srli s2, s2, 20                                            ;\
+        or s10, t3, s2                                              ;\
+    .endif                                                         ;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    test_mepc_S:                                                   ;\
+    .if (op==0)                                                    ;\
+        sfence.vma                                               ;\
+    .endif                                                         ;\
+    .if (op==0x01)                                                 ;\
+        csrw satp,t2                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    test_mepc_U:                                                   ;\
+    .if (op==0)                                                    ;\
+        sfence.vma                                               ;\
+    .endif                                                         ;\
+    .if (op==0x01)                                                 ;\
+        csrw satp,t2                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;
+
+#define PTE2_SETUP_RV32(PA, PR, TMP, VA, level)                     ;\
+    PTE(PA, PR)                                                    ;\
+    .if (level==1)                                                 ;\
+        la   TMP, pgtb2_l1                                          ;\
+        srli VA,  VA, 22                                           ;\
+    .endif                                                         ;\
+    .if (level==0)                                                 ;\
+        la   TMP, pgtb2_l0                                          ;\
+        slli VA,  VA, 10                                           ;\
+        srli VA,  VA, 22                                           ;\
+    .endif                                                         ;\
+    slli     VA,  VA,  2                                           ;\
+    add      TMP, TMP, VA                                          ;\
+    SREG     PA,  0(TMP)                                           ;
+
+#define SATP_SETUP2_SV32                                            ;\
+    la   t6,   pgtb2_l1                                             ;\
+    li   t5,   SATP32_MODE                                         ;\
+    srli t6,   t6, 12                                              ;\
+    or   t6,   t6, t5                                              ;\
+    li s5,1                                                        ;\
+    slli s5,s5, 22                                                 ;\
+    or t6, t6, s5                                                  ;\
+    WRITE_CSR(satp, t6)                                            ;
+
+
+#define ERROR1 0x444
+#define ERROR2 0x555
+#define ERROR3 0x666
+
+
+
+// #define TEST_PTE_VM_PMP_CHECK(MODE, LEVEL, R, W, X, A)         ;\
+//     .if(R == 1);\
+//         li s11, LOAD_ACCESS_FAULT;\
+//     .endif;\
+//     .if(W == 1);\
+//         li s11, STORE_AMO_ACCESS_FAULT;\
+//     .endif;\
+//     .if(X == 1);\
+//         li s11, INSTRUCTION_ACCESS_FAULT;\
+//     .endif                                                     ;\
+//     li t2, 0x80000800		                                       ;\
+//     srli t2, t2, 2;\
+// 	csrw pmpaddr0, t2                                              ;\
+//     li t2, 0x82000000		                                       ;\
+//     srli t2, t2, 2;\
+// 	csrw pmpaddr1, t2                                              ;\
+//     li t2, 0x84000000		                                       ;\
+//     srli t2, t2, 2;\
+// 	csrw pmpaddr2, t2                                              ;\
+//     la t2, test_seg		                                           ;\
+//     srli t2, t2, 2;\
+//     ori t2, t2, 0x0 ;\
+// 	csrw pmpaddr3, t2                                              ;\
+//     .if((R|W)==0&X==1) ;\
+// 	    li t2, 0x1F0B000F		                                   ;\
+//     .endif;\
+//     .if(R==0);\
+//         .if(W==1);\
+//         li t2, 0x1F0D000F		                                   ;\
+//         .endif;\
+//     .endif;\
+//     .if(R==1);\
+//         .if(W==0);\
+//         li t2, 0x1F0E000F		                                   ;\
+//         .endif;\
+//     .endif;\
+// 	csrw pmpcfg0, t2                                               ;\
+//     li t2, 0x23;\
+//     la t1, test_seg;\
+//     sw t2, 0(t1);\
+//     .if(LEVEL == 0)                                                ;\
+//         la a1, pgtb_l0                                             ;\
+//         GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+//         SET_PTE_V(a2, FLUSH)                                       ;\
+//         PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+//     .endif                                                         ;\
+//     .if(MODE == S_MODE)                                            ;\
+//         la a1, supervisor_code                                     ;\
+//     .else                                                          ;\
+//         la a1, user_code                                           ;\
+//         SET_PTE_U(a2, FLUSH)                                       ;\
+//     .endif                                                         ;\
+//     GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+//     mv t3, a0                                                      ;\
+//     .if(X == 1)                                                    ;\
+//         SET_PTE_X(a2, NO_FLUSH)                                    ;\
+//     .endif                                                         ;\
+//     SET_PTE_A(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_W(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_R(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_D(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_V(a2, NO_FLUSH)                                        ;\
+//     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+//     la a1, test_seg                                                ;\
+//     .if(LEVEL == 0)                                                ;\
+//         GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+//     .else                                                          ;\
+//         GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+//     .endif                                                         ;\
+//     mv t4, a0                                                      ;\
+//     .if(R == 1)                                                    ;\
+//         SET_PTE_R(a2, FLUSH)                                       ;\
+//     .endif                                                         ;\
+//     .if(W == 1)                                                    ;\
+//         SET_PTE_W(a2, NO_FLUSH)                                    ;\
+//     .endif                                                         ;\
+//     .if(A == 1)                                                    ;\
+//         SET_PTE_A(a2, NO_FLUSH)                                    ;\
+//     .endif                                                         ;\
+//     SET_PTE_D(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_V(a2, NO_FLUSH)                                        ;\
+//     .if(MODE == U_MODE)                                            ;\
+//         SET_PTE_U(a2, NO_FLUSH)                                    ;\
+//     .endif                                                         ;\
+//     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+//     la t1, tohost                                                  ;\
+//     mv a1, t1                                                      ;\
+//     .if(LEVEL == 0)                                                ;\
+//         GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+//     .else                                                          ;\
+//         GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+//     .endif                                                         ;\
+//     mv s1, a0                                                      ;\
+//     SET_RWXV_BITS(a2, FLUSH)                                       ;\
+//     SET_PTE_A(a2, NO_FLUSH)                                        ;\
+//     SET_PTE_D(a2, NO_FLUSH)                                        ;\
+//     .if(MODE == U_MODE)                                            ;\
+//         SET_PTE_U(a2, NO_FLUSH)                                    ;\
+//     .endif                                                         ;\
+//     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+//     SATP_SETUP_SV32                                                ;\
+//     la t2, trap_handler                                            ;\
+//     WRITE_CSR (mtvec, t2)                                          ;\
+//     WRITE_CSR (mepc, t3)                                           ;\
+//     li t2, 0x1800                                                  ;\
+//     CLEAR_CSR (mstatus, t2)                                        ;\
+//     .if(MODE == S_MODE)                                            ;\
+//         li t2,  0x00800                                            ;\
+//     .else                                                          ;\
+//         li t2, 0xC0000                                             ;\
+//     .endif                                                         ;\
+//     SET_CSR (mstatus, t2)                                          ;\
+//         .if(X == 1);\
+//         srli t3, t3, 12;\
+//         slli t3, t3, 12;\
+//         .if(MODE == S_MODE);\
+//             la s2, test_mepc_S;\
+//         .else;\
+//             la s2, test_mepc_U;\
+//         .endif;\
+//         slli s2, s2, 20;\
+//         srli s2, s2, 20;\
+//         or s10, t3, s2;\
+//     .endif;\
+//     MRET                                                           ;\
+//     supervisor_code:                                               ;\
+//     test_mepc_S:;\
+//     li t1, 0x45                                                    ;\
+//     .if(R == 1)                                                    ;\
+//         lw t1, 0(t4)                                               ;\
+//     .endif                                                         ;\
+//     .if(W == 1)                                                    ;\
+//         sw t1, 0(t4)                                               ;\
+//     .endif                                                         ;\
+//     j exit                                                         ;\
+//     user_code:                                                     ;\
+//     test_mepc_U:;\
+//     li t1, 0x45                                                    ;\
+//     .if(R == 1)                                                    ;\
+//         lw t1, 0(t4)                                               ;\
+//     .endif                                                         ;\
+//     .if(W == 1)                                                    ;\
+//         sw t1, 0(t4)                                               ;\
+//     .endif                                                         ;\
+//     li x1, 1                                                       ;\
+//     j exit                                                         ;
+
+
+
+#define TEST_PTE_VM_PMP_CHECK(MODE, LEVEL, R, W, X, A)         ;\
+    .if(R == 1);\
+        li s11, LOAD_ACCESS_FAULT                            ;\
+    .endif;\
+    .if(W == 1);\
+        li s11, STORE_AMO_ACCESS_FAULT;\
+    .endif;\
+    .if(X == 1);\
+        li s11, INSTRUCTION_ACCESS_FAULT;\
+    .endif                                                     ;\
+    .if(W & X == 1);\
+        li s11, STORE_AMO_ACCESS_FAULT;\
+    .endif                                                         ;\
+    li t2, 0x80000800		                                       ;\
+    srli t2, t2, 2;\
+	csrw pmpaddr0, t2                                              ;\
+    li t2, 0x82000000		                                       ;\
+    srli t2, t2, 2;\
+	csrw pmpaddr1, t2                                              ;\
+    li t2, 0x84000000		                                       ;\
+    srli t2, t2, 2;\
+	csrw pmpaddr2, t2                                              ;\
+    la t2, test_seg		                                           ;\
+    srli t2, t2, 2;\
+    ori t2, t2, 0x0 ;\
+	csrw pmpaddr3, t2                                              ;\
+    .if((R|W)==0&X==1) ;\
+	    li t2, 0x1F0B000F		                                   ;\
+    .endif;\
+    .if(R==0);\
+        .if(W==1);\
+        li t2, 0x1F0D000F		                                   ;\
+        .endif;\
+    .endif;\
+    .if(R==1);\
+        .if(W==0);\
+        li t2, 0x1F0E000F		                                   ;\
+        .endif;\
+    .endif;\
+	csrw pmpcfg0, t2                                               ;\
+    li t2, 0x23;\
+    la t1, test_seg;\
+    sw t2, 0(t1);\
+    .if(LEVEL == 0)                                                ;\
+        la a1, pgtb_l0                                             ;\
+        GEN_VA(a1, a0, 0x003, 0x002)                               ;\
+        SET_PTE_V(a2, FLUSH)                                       ;\
+        PTE_SETUP_RV32(a1, a2, t1, a0, 1)                          ;\
+    .endif                                                         ;\
+    .if(MODE == S_MODE)                                            ;\
+        la a1, supervisor_code                                     ;\
+    .else                                                          ;\
+        la a1, user_code                                           ;\
+        SET_PTE_U(a2, FLUSH)                                       ;\
+    .endif                                                         ;\
+    GEN_VA(a1, a0, 0x003, 0x000)                                   ;\
+    mv t3, a0                                                      ;\
+    .if(X == 1)                                                    ;\
+        SET_PTE_X(a2, NO_FLUSH)                                    ;\
+    .endif                                                         ;\
+    SET_PTE_A(a2, NO_FLUSH)                                        ;\
+    SET_PTE_W(a2, NO_FLUSH)                                        ;\
+    SET_PTE_R(a2, NO_FLUSH)                                        ;\
+    SET_PTE_D(a2, NO_FLUSH)                                        ;\
+    SET_PTE_V(a2, NO_FLUSH)                                        ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la a1, pgtb_l1                                                 ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x004)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x004, 0x000)                               ;\
+    .endif                                                         ;\
+    mv t4, a0                                                      ;\
+    SET_PTE_R(a2, FLUSH)                                           ;\
+    SET_PTE_W(a2, NO_FLUSH)                                        ;\
+    SET_PTE_X(a2, NO_FLUSH)                                        ;\
+    SET_PTE_A(a2, NO_FLUSH)                                        ;\
+    SET_PTE_D(a2, NO_FLUSH)                                        ;\
+    SET_PTE_V(a2, NO_FLUSH)                                        ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_FLUSH)                                    ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    la t1, tohost                                                  ;\
+    mv a1, t1                                                      ;\
+    .if(LEVEL == 0)                                                ;\
+        GEN_VA(a1, a0, 0x003, 0x005)                               ;\
+    .else                                                          ;\
+        GEN_VA(a1, a0, 0x005, 0x000)                               ;\
+    .endif                                                         ;\
+    mv s1, a0                                                      ;\
+    SET_RWXV_BITS(a2, FLUSH)                                       ;\
+    SET_PTE_A(a2, NO_FLUSH)                                        ;\
+    SET_PTE_D(a2, NO_FLUSH)                                        ;\
+    .if(MODE == U_MODE)                                            ;\
+        SET_PTE_U(a2, NO_FLUSH)                                    ;\
+    .endif                                                         ;\
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL)                          ;\
+    SATP_SETUP_SV32                                                ;\
+    la t2, trap_handler                                            ;\
+    WRITE_CSR (mtvec, t2)                                          ;\
+    WRITE_CSR (mepc, t3)                                           ;\
+    li t2, 0x1800                                                  ;\
+    CLEAR_CSR (mstatus, t2)                                        ;\
+    .if(MODE == S_MODE)                                            ;\
+        li t2,  0x00800                                            ;\
+    .else                                                          ;\
+        li t2, 0xC0000                                             ;\
+    .endif                                                         ;\
+    SET_CSR (mstatus, t2)                                          ;\
+        .if(X == 1);\
+        srli t3, t3, 12;\
+        slli t3, t3, 12;\
+        .if(MODE == S_MODE);\
+            la s2, test_mepc_S;\
+        .else;\
+            la s2, test_mepc_U;\
+        .endif;\
+        slli s2, s2, 20;\
+        srli s2, s2, 20;\
+        or s10, t3, s2;\
+    .endif;\
+    MRET                                                           ;\
+    supervisor_code:                                               ;\
+    li t1, 0x45                                                    ;\
+    test_mepc_S:;\
+    .if(R == 1)                                                    ;\
+        lw t1, 8(t1)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    j exit                                                         ;\
+    user_code:                                                     ;\
+    test_mepc_U:;\
+    li t1, 0x45                                                    ;\
+    .if(R == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    .if(W == 1)                                                    ;\
+        sw t1, 0(t4)                                               ;\
+    .endif                                                         ;\
+    li x1, 1                                                       ;\
+    j exit                                                         ;
+
+
+
+#define RVTEST_EXIT_LOGIC                                          ;\
+exit:                                                              ;\
+    la t0, tohost                                                  ;\
+    li t1, 1                                                       ;\
+    EXIT_LOGIC(t0, t1)                                             ;\
+    j exit                                                         ;
+
+#define COREV_VERIF_EXIT_LOGIC                                     ;\
+exit:                                                              ;\
+	slli x1, x1, 1                                                 ;\
+    addi x1, x1, 1                                                 ;\
+    mv x30, s1                                                     ;\
+	sw x1, tohost, x30                                             ;\
+	self_loop: j self_loop                                         ;
+
+
+    #define _start   rvtest_entry_point                            
+
+    #define RVTEST_DATA_SECTION_MISALIGNED                         ;\
+    .data                                                          ;\
+    pgtb_l1:                                                       ;\
+        .zero 4096                                                 ;\
+    pgtb_l0:                                                       ;\
+        .zero 4096                                                 ;\
+    .align 16                                                      ;\
+    arr:                                                           ;\
+        .word 0x23                                                 ;
+        

--- a/cva6/tests/custom/sv32/satp_access_permission.S
+++ b/cva6/tests/custom/sv32/satp_access_permission.S
@@ -1,0 +1,56 @@
+#################################################################################################           
+#                                                                                               #
+# Verification Goal:   SATP is accessible only in M and S mode not in U mode                    #
+#                                                                                               #
+# Description:         Satp is only accessible in M and S mode and illegal instruction          #
+#                      exception is generated when accessed in lower privilege mode             #
+#                                                                                               #
+# Sub Feature:         Access permission                                                        #                
+#                                                                                               #   
+# Feature Discription: Access satp in M, S, and U mode using csrrw, csrrc, csrrs                #   
+#                                                                                               #
+#################################################################################################   
+
+#include "macros.h"
+
+.text
+.global rvtest_entry_point
+rvtest_entry_point:
+
+    ALL_MEM_PMP                    # set the PMP permissions
+    TRAP_HANDLER(trap_handler)     # set mtvec for trap
+    li s1, ALL_F_S
+    li s2, SATP32_PPN
+    li s3, SATP32_ASID
+    la s10, user_mode               
+    li s11, ILLEGAL_INSTRUCTION
+
+machine_mode:
+
+    CLEAR_CSR (satp,s1)
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+    la t4, supervisor_mode                             
+    CHANGE_T0_S_MODE(t4)           # changes mode from M to S
+
+supervisor_mode:
+
+    CLEAR_CSR (satp,s1)
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+    la t4, user_mode                
+    CHANGE_T0_U_MODE(t4)           # changes mode from S to U
+
+user_mode:
+
+    CLEAR_CSR (satp,s1)            # Illegal instruction exception is generated when accessed in U mode 
+    SET_CSR   (satp,s2)
+    WRITE_CSR (satp,s3)
+    j exit
+
+ABit_trap_handler                 # trap handler      
+COREV_VERIF_EXIT_LOGIC            # exit logic  
+
+.data
+.align 4; .global tohost;   tohost:   .dword 0;                    
+.align 4; .global fromhost; fromhost: .dword 0;    


### PR DESCRIPTION
This pull request contains the following test plans for the SV32 tests:

**Test 1: Access SATP Permission** (satp_access_permission.S)
- This test checks that SATP is only accessible in M and S mode, not in U mode.

**Test 2: Invalid Permission of PTE** (InValid-Permission_of_PTE_01.S to InValid-Permission_of_PTE_12.S)

-  If PTE does not have the Valid (pte.V=0) permission, accessing it would raise a page fault exception of the corresponding access type. 

- When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, the following tests are performed in supervisor and user privilege mode for level 0 and level 1 PTE:
1. Set PTE.V = 0 and test the read access.
2. Set PTE.V = 0 and test the write access.
3. Set PTE.V = 0 and test the execute access.

For testing at level 0, all the PTE permissions at level 1 are set to 0 except pte.v, so that level 1 points to level 0. Set pte.U=0 when testing in Supervisor mode and set pte.U=1 when testing in user mode.

**Test 3: RWX Access on S-mode Pages in S-mode** (RWX_Access_S_01.S to RWX_Access_S_12.S)

- If PTE belongs to supervisor mode (pte.u = 0) and has the corresponding (r,w,x) permission granted, accessing that PTE in supervisor mode should be successful. Otherwise, it should raise a page fault exception of the corresponding access type.

- When satp.mode=sv32, PTE has (r,w,x) PMP permissions, non-reserved RWX encoding, pte.u=0, and pte.v=1, the following tests are performed in supervisor privilege mode for level 0 and level 1 PTE:

1. Test the read access for both pte.r=1 and for pte.r=0.
2. Test the write access for both pte.w=1 and for pte.w=0.
3. Test the execute access for both pte.x=1 and for pte.x=0.

For testing at level 0, all the PTE permissions at level 1 are set to 0 except pte.v, so that level 1 points to level 0.

**Test 4: RWX Access on U-mode Pages in S-mode with s/mstatus.SUM Set** ( RWX_Access_U_01.S to RWX_Access_U_06.S)

- If PTE belongs to user mode (pte.u = 1) and m/sstatus.SUM = 1, RW access to that PTE in supervisor mode would be successful, but execute access would raise an instruction page fault exception in S-mode.

- When satp.mode=sv32, PTE has (r,w,x) PMP permissions, non-reserved RWX encoding, and pte.v=1, the following tests are performed in supervisor mode for level 0 and level 1 PTE:

1. Set pte.r=1 & pte.u=1 & s/mstatus.SUM = 1 and test the read access.
2. Set pte.w=1 & pte.u=1 & s/mstatus.SUM = 1 and test the write access.
3. Set pte.x=1 & pte.u=1 & s/mstatus.SUM = 1 and test the execute access.

**Test 5: Misaligned Superpage** (Misaligned_Superpage01.S to Misaligned_Superpage06.S)

- If PTE at level 1 is a leaf PTE (superpage) and pte.ppn[0]=0, it is a misaligned superpage, and accessing that PTE would raise a page fault exception of the corresponding access type.

- When satp.mode=sv32, PTE has (r,w,x) PMP permissions, non-reserved RWX encodings, (pte.r | pte.x)=1, and pte.v=1, the following tests are performed in supervisor and user privilege mode for level 1 PTE:

- Set pte.ppn[0]=0 and test for read, write, and execute access. Set pte.U=0 when testing in Supervisor mode and set pte.U=1 when testing in user mode
