### PR TITLE
SV32-Hammad-tests

### DIFF
--- a/cva6/tests/custom/sv32/tests/mstatus_tvm-01.S
+++ b/cva6/tests/custom/sv32/tests/mstatus_tvm-01.S
@@ -1,0 +1,31 @@
+#include "macros.h"
+#define Test_Access_Bit
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):0, R(PTE):1, W(PTE):1, X(PTE):1, XA(PTE):0, A(PTE):0
+    #TEST_ACCESS_BIT(0x02, 0, 1, 1, 1, 0, 0)
+    TEST_MSTATUS_TVM_SATP(0x01, 0, 0)
+
+    #ifdef Test_Access_Bit
+    ABit_trap_handler
+    #endif
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/mstatus_tvm-02.S
+++ b/cva6/tests/custom/sv32/tests/mstatus_tvm-02.S
@@ -1,0 +1,31 @@
+#include "macros.h"
+#define Test_Access_Bit
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):0, R(PTE):1, W(PTE):1, X(PTE):1, XA(PTE):0, A(PTE):0
+    #TEST_ACCESS_BIT(0x02, 0, 1, 1, 1, 0, 0)
+    TEST_MSTATUS_TVM_SATP(0x01, 0, 1)
+
+    #ifdef Test_Access_Bit
+    ABit_trap_handler
+    #endif
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/satp_mode_sv32.S
+++ b/cva6/tests/custom/sv32/tests/satp_mode_sv32.S
@@ -1,0 +1,24 @@
+#include "macros.h"
+.section .text
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    ALL_MEM_PMP
+    li t0, SATP32_MODE
+    WRITE_CSR(satp, t0)
+    READ_CSR(satp, t1)
+    beq t1, t0, exit
+    li x1, 1
+    j exit
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/tests/vmDirtyBit-01.S
+++ b/cva6/tests/custom/sv32/tests/vmDirtyBit-01.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Supervisor mode-- Level 1 -- Read bit = 1 -- Write Bit = 1 -- Execute Bit = 1 -- Execute Dirty bit = 1 -- Dirty Bit = 0 
+    TEST_DIRTY_BIT(0x01, 1, 1, 1, 1)
+    ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmDirtyBit-02.S
+++ b/cva6/tests/custom/sv32/tests/vmDirtyBit-02.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Supervisor mode-- Level 1 -- Read bit = 1 -- Write Bit = 1 -- Execute Bit = 1 -- Execute Dirty bit = 1 -- Dirty Bit = 0 
+    TEST_DIRTY_BIT(0x00, 1, 1, 1, 1)
+    nop    
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmDirtyBit-03.S
+++ b/cva6/tests/custom/sv32/tests/vmDirtyBit-03.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Supervisor mode-- Level 1 -- Read bit = 1 -- Write Bit = 1 -- Execute Bit = 1 -- Execute Dirty bit = 1 -- Dirty Bit = 0 
+    TEST_DIRTY_BIT(0x01, 0, 1, 1, 1)
+    ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmDirtyBit-04.S
+++ b/cva6/tests/custom/sv32/tests/vmDirtyBit-04.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Supervisor mode-- Level 1 -- Read bit = 1 -- Write Bit = 1 -- Execute Bit = 1 -- Execute Dirty bit = 1 -- Dirty Bit = 0 
+    TEST_DIRTY_BIT(0x00, 0, 1, 1, 1)
+    ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmMXRset-01.S
+++ b/cva6/tests/custom/sv32/tests/vmMXRset-01.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):1, R(PTE):0, W(PTE):0, X(PTE):1
+    TEST_MXR_SET(0x01, 1, 0, 0, 1)
+    nop
+ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmMXRset-02.S
+++ b/cva6/tests/custom/sv32/tests/vmMXRset-02.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XA(PTE):1, A(PTE):1
+    TEST_MXR_SET(0x00, 1, 0, 0, 1)
+    nop
+ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmMXRset-03.S
+++ b/cva6/tests/custom/sv32/tests/vmMXRset-03.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1
+    TEST_MXR_SET(0x01, 0, 0, 0, 1)
+ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmMXRset-04.S
+++ b/cva6/tests/custom/sv32/tests/vmMXRset-04.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    # BitFields
+    # MODE:S_MODE LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1
+    TEST_MXR_SET(0x00, 0, 0, 0, 1)
+ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-01.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-01.S
@@ -1,0 +1,26 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x01, 0, 0, 0, 0, 1, 0x00)
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-02.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-02.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+#define Test_Access_Bit
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x01, 0, 0, 0, 0, 1, 0x01)
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-03.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-03.S
@@ -1,0 +1,28 @@
+#include "macros.h"
+#define Test_Access_Bit
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x01, 0, 0, 0, 0, 0, 0x00)
+    nop
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-04.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-04.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x00, 0, 0, 0, 0, 1, 0x00)
+    nop
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-05.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-05.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x00, 0, 0, 0, 0, 1, 0x01)
+    nop
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmNLeafPTE-06.S
+++ b/cva6/tests/custom/sv32/tests/vmNLeafPTE-06.S
@@ -1,0 +1,27 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:0
+    TEST_Nonleaf_PTE(0x02, 0, 0, 0, 0, 0, 0x00)
+
+    ABit_trap_handler
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-01.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-01.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 1, 0, 1, 0, 1, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-02.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-02.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 1, 0, 1, 0, 1, 0x01)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-03.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-03.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 1, 0, 1, 0, 0, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-04.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-04.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 1, 0, 1, 0, 1, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-05.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-05.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 1, 0, 1, 0, 1, 0x01)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-06.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-06.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 1, 0, 1, 0, 0, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-07.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-07.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 0, 0, 1, 0, 1, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-08.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-08.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 0, 0, 1, 0, 1, 0x01)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-09.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-09.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:S_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x01, 0, 0, 1, 0, 0, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-10.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-10.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Read Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 0, 0, 1, 0, 1, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-11.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-11.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Write Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 0, 0, 1, 0, 1, 0x01)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096

--- a/cva6/tests/custom/sv32/tests/vmRWXreserved-12.S
+++ b/cva6/tests/custom/sv32/tests/vmRWXreserved-12.S
@@ -1,0 +1,29 @@
+#include "macros.h"
+.text
+.globl rvtest_entry_point
+rvtest_entry_point:
+    #Execute Test
+    # MODE:U_Mode LEVEL(PTE):0, R(PTE):0, W(PTE):0, X(PTE):1, XS(PTE):1, op_check:1
+    TEST_Reserved_RWX(0x00, 0, 0, 1, 0, 0, 0x00)
+
+ABit_trap_handler
+
+exit:
+	slli x1, x1, 1
+	addi x1, x1, 1
+    mv x30, s1
+	sw x1, tohost, x30
+	self_loop: j self_loop           
+
+.data
+test_seg:
+    .word 0x23
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;
+.align 24
+pgtb_l1:
+    .zero 4096
+pgtb_l0:
+    .zero 4096
+pgtb_l0_1:
+    .zero 4096


### PR DESCRIPTION
**SATP -- feature MODE Field**
Allows to select different schemes of address translation. Writes to satp are ignored when unsupported mode is selected.
