### PR TITLE
SV32-DV-plan execution

### DIFF
--- a/cva6/tests/custom/sv32/macros.h
+++ b/cva6/tests/custom/sv32/macros.h
@@ -1,26 +1,27 @@
 #include "encoding.h"
 
 #define _start   rvtest_entry_point                            
+#define SMODE_ECALL ecall
+#define UMODE_ECALL ecall
 
 #define LEVEL0 0x00
 #define LEVEL1 0x01
 
-#define OFFSET_SHIFT 12
 #define SUPERPAGE_SHIFT 22
 
 #define PTE(PA, PR)                                                ;\
-    srli     PA, PA, OFFSET_SHIFT                                  ;\
+    srli     PA, PA, RISCV_PGSHIFT                                 ;\
     slli     PA, PA, PTE_PPN_SHIFT                                 ;\
     or       PA, PA, PR                                            ;
 
-#define PTE_SETUP_RV32(PA, PR, TMP, VA, level)                     ;\
+#define PTE_SETUP_RV32(PA, PR, TMP, VA, PGTB_ADDR,LEVEL)           ;\
     PTE(PA, PR)                                                    ;\
-    .if (level==1)                                                 ;\
-        la   TMP, pgtb_l1                                          ;\
+    .if (LEVEL==1)                                                 ;\
+        la   TMP, PGTB_ADDR                                        ;\
         srli VA,  VA, SUPERPAGE_SHIFT                              ;\
     .endif                                                         ;\
-    .if (level==0)                                                 ;\
-        la   TMP, pgtb_l0                                          ;\
+    .if (LEVEL==0)                                                 ;\
+        la   TMP, PGTB_ADDR                                        ;\
         slli VA,  VA, PTE_PPN_SHIFT                                ;\
         srli VA,  VA, SUPERPAGE_SHIFT                              ;\
     .endif                                                         ;\
@@ -31,7 +32,7 @@
 #define SATP_SETUP_SV32(PGTB_ADDR)                                 ;\
     la   t6,   PGTB_ADDR                                           ;\
     li   t5,   SATP32_MODE                                         ;\
-    srli t6,   t6, OFFSET_SHIFT                                    ;\
+    srli t6,   t6, RISCV_PGSHIFT                                   ;\
     or   t6,   t6, t5                                              ;\
     csrw satp, t6                                                  ;\
     sfence.vma                                                     ;
@@ -60,21 +61,41 @@ exit:                                                              ;\
 
 #define COREV_VERIF_EXIT_LOGIC                                     ;\
 exit:                                                              ;\
-	slli x1, x1, 1                                                 ;\
+    slli x1, x1, 1                                                 ;\
     addi x1, x1, 1                                                 ;\
     mv x30, s1                                                     ;\
-	sw x1, tohost, x30                                             ;\
-	self_loop: j self_loop                                         ;
+    sw x1, tohost, x30                                             ;\
+    self_loop: j self_loop                                         ;
 
 #define ALL_MEM_PMP                                                ;\
-    li t2, -1		                                               ;\
-	csrw pmpaddr0, t2                                              ;\
-	li t2, 0x0F		                                               ;\
-	csrw pmpcfg0, t2                                               ;\
+    li t2, -1		                                           ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F		                                           ;\
+    csrw pmpcfg0, t2                                               ;\
     sfence.vma                                                     ;
 
-#define INCREMENT_MEPC                                             ;\
-   csrr t3,mepc                                                    ;\
-    addi t3,t3,4                                                   ;\
-    csrw mepc,t3                                                   ;
- 
+#define TEST_PROLOG(ADDR,CAUSE)                                    ;\
+    la t1, rvtest_check                                            ;\
+    la t2, ADDR                                                    ;\
+    li t3, CAUSE                                                   ;\
+    li t4, 1                                                       ;\
+    sw t4, 0(t1)                                                   ;\
+    sw t2, 4(t1)                                                   ;\
+    sw t3, 8(t1)                                                   ;\
+    la a1,rvtest_data                                              ; 
+
+.macro INCREMENT_MEPC label_suffix                                 ;\
+    csrr t1, mepc                                                  ;\
+    lw t5, 0(t1)                                                   ;\
+    li t2, 3                                                       ;\
+    and t2, t2, t5                                                 ;\
+    li t3, 3                                                       ;\
+    bne t2, t3, not_32_bit_Instr_\label_suffix                     ;\
+    addi t1, t1, 4                                                 ;\
+    j write_mepc_\label_suffix                                     ;\
+    not_32_bit_Instr_\label_suffix:                                ;\
+    addi t1, t1, 2                                                 ;\ 
+    write_mepc_\label_suffix:                                      ;\
+    csrw mepc, t1                                                  ;\
+.endm                                                              ;
+

--- a/cva6/tests/custom/sv32/macros.h
+++ b/cva6/tests/custom/sv32/macros.h
@@ -1,0 +1,80 @@
+#include "encoding.h"
+
+#define _start   rvtest_entry_point                            
+
+#define LEVEL0 0x00
+#define LEVEL1 0x01
+
+#define OFFSET_SHIFT 12
+#define SUPERPAGE_SHIFT 22
+
+#define PTE(PA, PR)                                                ;\
+    srli     PA, PA, OFFSET_SHIFT                                  ;\
+    slli     PA, PA, PTE_PPN_SHIFT                                 ;\
+    or       PA, PA, PR                                            ;
+
+#define PTE_SETUP_RV32(PA, PR, TMP, VA, level)                     ;\
+    PTE(PA, PR)                                                    ;\
+    .if (level==1)                                                 ;\
+        la   TMP, pgtb_l1                                          ;\
+        srli VA,  VA, SUPERPAGE_SHIFT                              ;\
+    .endif                                                         ;\
+    .if (level==0)                                                 ;\
+        la   TMP, pgtb_l0                                          ;\
+        slli VA,  VA, PTE_PPN_SHIFT                                ;\
+        srli VA,  VA, SUPERPAGE_SHIFT                              ;\
+    .endif                                                         ;\
+    slli     VA,  VA,  2                                           ;\
+    add      TMP, TMP, VA                                          ;\
+    sw     PA,  0(TMP)                                             ;
+
+#define SATP_SETUP_SV32(PGTB_ADDR)                                 ;\
+    la   t6,   PGTB_ADDR                                           ;\
+    li   t5,   SATP32_MODE                                         ;\
+    srli t6,   t6, OFFSET_SHIFT                                    ;\
+    or   t6,   t6, t5                                              ;\
+    csrw satp, t6                                                  ;\
+    sfence.vma                                                     ;
+
+#define CHANGE_T0_S_MODE(MEPC_ADDR)                                ;\
+    li        t0, MSTATUS_MPP                                      ;\
+    csrc mstatus, t0                                               ;\
+    li  t1, MSTATUS_MPP & ( MSTATUS_MPP >> 1)                      ;\
+    csrs mstatus, t1                                               ;\
+    csrw mepc, MEPC_ADDR                                           ;\
+    mret                                                           ;
+
+#define CHANGE_T0_U_MODE(MEPC_ADDR)                                ;\
+    li        t0, MSTATUS_MPP                                      ;\
+    csrc mstatus, t0                                               ;\
+    csrw mepc, MEPC_ADDR                                           ;\
+    mret                                                           ;
+
+
+#define RVTEST_EXIT_LOGIC                                          ;\
+exit:                                                              ;\
+    la t0, tohost                                                  ;\
+    li t1, 1                                                       ;\
+    sw t1, 0(t0)                                                   ;\
+    j exit                                                         ;
+
+#define COREV_VERIF_EXIT_LOGIC                                     ;\
+exit:                                                              ;\
+	slli x1, x1, 1                                                 ;\
+    addi x1, x1, 1                                                 ;\
+    mv x30, s1                                                     ;\
+	sw x1, tohost, x30                                             ;\
+	self_loop: j self_loop                                         ;
+
+#define ALL_MEM_PMP                                                ;\
+    li t2, -1		                                               ;\
+	csrw pmpaddr0, t2                                              ;\
+	li t2, 0x0F		                                               ;\
+	csrw pmpcfg0, t2                                               ;\
+    sfence.vma                                                     ;
+
+#define INCREMENT_MEPC                                             ;\
+   csrr t3,mepc                                                    ;\
+    addi t3,t3,4                                                   ;\
+    csrw mepc,t3                                                   ;
+ 

--- a/cva6/tests/custom/sv32/vm_invalid_pte01.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte01.S
@@ -82,7 +82,7 @@ PTE_LEVEL1_SUPERVISOR:
 
     la a1,rvtest_check                                                     # loads the address of label rvtest_data
     mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_W | PTE_R | PTE_V )                                  # sets the permission bits
+    ori a2, x0, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )                                  # sets the permission bits
     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
 
 # ----------------Set the SATP and change the mode---------------------
@@ -97,6 +97,7 @@ PTE_LEVEL1_SUPERVISOR:
 vm_en:
 
     li t1,10
+    
 pre_load:
 
     la t1, rvtest_check
@@ -177,11 +178,12 @@ PTE_LEVEL1_USER_EXECUTE:
 
 check_execute:
     li t1, 0x45                                                             # page fault should raise 
+   
+    la a1, rvtest_data
+    lw t1,8(a1)
+    bne t1, x0,exit 
+    sw t4,8(a1)
 
-    addi s11,s11,1
-    li t1,1
-    beq s11,t1,PTE_LEVEL1_USER
-    j exit
 
 PTE_LEVEL1_USER:
 
@@ -224,7 +226,7 @@ RVTEST_EXIT_LOGIC                                                           # Ex
     rvtest_data:   
         .word 0xbeefcafe                                                 
         .word 0xdeadcafe                                                 
-        .word 0xcafecafe                                                 
+        .word 0x00000000                                                 
         .word 0x00000000 
 .align 12                                                      
     pgtb_l1:                                                       

--- a/cva6/tests/custom/sv32/vm_invalid_pte01.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte01.S
@@ -1,5 +1,6 @@
 #=======================================================================
-#   🌟 In-Valid Permission of Level1 PTE 🌟
+#   🌟 RWX Access of Level1 PTE in User and Supervisor mode when valid
+#      bit is low  🌟
 #-----------------------------------------------------------------------
 # Test Description:
 #
@@ -17,217 +18,156 @@
 
 #include "macros.h"
 
-trap_handler:
+#ifdef smode
+    #define SET_PTE_U 0
+#else
+    #define SET_PTE_U PTE_U
+#endif
 
-    csrr t0, mcause                                                        # read the value of mcause 
-    la t1, rvtest_check                                                    # load the address of trvtest_check
-    
-    lw t2, 0(t1)                                                           # if cause expected then load 1 else 0
-    lw t3, 4(t1)                                                           # load the expected value of mepc 
-    lw t4, 8(t1)                                                           # load the expected value of mcause  
-
-    li  t1, CAUSE_SUPERVISOR_ECALL                                         # load the value of supervisor ecall
-    beq t0,t1,next_instr                                                   # checks if ecall is occured
-
-    li  t1, CAUSE_USER_ECALL                                               # load the value of user ecall
-    beq t0,t1,next_instr                                                   # checks for ecall is occured
-
-    beqz t2, exit                                                          # Jumps to exit if cause is not expected
- 
-    csrr t5,mepc                                                           # read the value of mepc 
-    bne t3,t5,exit                                                         # check the value of mepc with it's expected value
-
-    bne  t0, t4, exit                                                      # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
-
-    li t5, CAUSE_FETCH_ACCESS                                              # load the value of fetch access fault
-    beq t0, t5, next_instr                                                 # if fetch access fault jump to next instr in M mode  
-
-    li t5, CAUSE_FETCH_PAGE_FAULT                                          # load the value of fetch page fault exception 
-    beq t0,t5,next_instr                                                   # if fetch page fault jump to next instr in M mode
-
-
-continue_execution:
-
-    INCREMENT_MEPC                                                         # update the value of mepc 
-    mret
-
-next_instr:
-
-    INCREMENT_MEPC                                                         # update the value of mepc 
-    li t1,MSTATUS_MPP                                                      # update the MPP to MSTATUS_MPP for M mode
-    csrs mstatus,t1                                                        # update the value mstatus MPP 
-    mret
+#define _MMODE_  "M"
+#define _SUMODE_ "SU"
 
 .text
 .global _start
 
 _start:
-    ALL_MEM_PMP                                                            # PMP permission to all the mem
+    ALL_MEM_PMP                                                            # PMP permission to all the memory
     la t1,trap_handler                                                     # loads the address of trap handler 
     csrw mtvec,t1                                                          # sets the mtvec to trap handler 
     
-PTE_LEVEL1_SUPERVISOR:
-
 # ----------------LEVEL 1 PTE Setup for load and store test------------
 
     la a1,vm_en                                                            # loads the address of label vm_en
-    mv a0, a1                                                              # generrates the VA for label vm_en
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )          # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_V )              # sets the permission bits
+    PTE_SETUP_RV32 ( a1, a2, t1, a0, pgtb_l1, LEVEL1 )                     # setup the PTE for level1
  
     la a1,rvtest_data                                                      # loads the address of label rvtest_data
-    mv a0, a1                                                              # generrates the VA for label rvtest_data
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                  # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1   
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_W | PTE_R )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1   
 
     la a1,rvtest_check                                                     # loads the address of label rvtest_data
-    mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V )                                  # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+    mv a0, a1                                                              # set the VA to PA (identity mapping)                                          
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_W | PTE_R | PTE_V )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1
 
-# ----------------Set the SATP and change the mode---------------------
-
+# ----------------Set the SATP and change the mode----------------------
 
     SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
-    la a1,vm_en                                                            # loads the address of vm_en 
-    CHANGE_T0_S_MODE(a1)                                                   # changes mode M to S and set the MEPC value to a1
+    la a1,vm_en                                                            # loads the address of vm_en
+    #ifdef smode																													 
+        CHANGE_T0_S_MODE(a1)                                        	   # changes mode M to S and set the MEPC value to a1
+    #else
+        CHANGE_T0_U_MODE(a1)                                        	   # changes mode M to U and set the MEPC value to a1
+    #endif
 
-# ----------------Virtualization Enabeled------------------------------
+# ----------------Virtualization Enabeled-------------------------------
 
 vm_en:
 
-    li t1,10
+    li t1,10                                                               
     
 pre_load:
 
-    la t1, rvtest_check
-    la t2, check_load
-    li t3, CAUSE_LOAD_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    TEST_PROLOG(check_load,CAUSE_LOAD_PAGE_FAULT)                           # load the addr and expected cause 
     la a1, rvtest_data                                                      # loads the address of label rvtest_data
 
 check_load:
 
-    lw t1,0(a1)  
+    lw t1,0(a1)                                                             # tests the load access 
     nop
 
 pre_store:
 
-    la t1, rvtest_check
-    la t2, check_store
-    li t3, CAUSE_STORE_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    TEST_PROLOG(check_store,CAUSE_STORE_PAGE_FAULT)                         # load the addr and expected cause 
     la a1,rvtest_data                                                       # loads the address of label rvtest_data
 
 check_store:
-    sw t1,0(a1)
+    sw t1,0(a1)                                                             # test the store access
     nop                          
-    ecall
+    SMODE_ECALL                                                             # ecall to go to m mode
 
 pre_execute:
 
-    la t1, rvtest_check
-    la t2, check_execute
-    li t3, CAUSE_FETCH_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
-    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+    TEST_PROLOG(check_execute,CAUSE_FETCH_PAGE_FAULT)                       # load the addr and expected cause 
 
-    lw t1,12(a1)
-    bne t1, x0,PTE_LEVEL1_USER_EXECUTE 
-    sw t4,12(a1)
-    
-PTE_LEVEL1_SUPERVISOR_EXECUTE:
-
-# -------------LEVEL 1 PTE Setup for execute test----------------------
-                                                                            # Setup a new PTE to test execute 
+# -------------LEVEL 1 PTE Setup for execute test------------------------
+                                                                            # Setup a new PTE to test execute
     la a1,check_execute                                                     # loads the address of label vm_en
-    mv a0, a1 
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                   # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+    mv a0, a1                                                               # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X )                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                         # setup the PTE for level1
 
 # ----------------Set the SATP and change the mode---------------------
 
     SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
     la a1,check_execute                                                     # loads the address of check_execute
-    CHANGE_T0_S_MODE(a1)                                                    # changes mode M to S and set the MEPC 
-
-PTE_LEVEL1_USER_EXECUTE:
-
-# -------------LEVEL 1 PTE Setup for execute test----------------------
-                                                                            # Setup a new PTE to test execute 
-    la a1,check_execute                                                     # loads the address of label vm_en
-    mv a0, a1 
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
-
-# ----------------Set the SATP and change the mode---------------------
-
-    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
-    la a1,check_execute                                                     # loads the address of check_execute
-    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+    #ifdef smode
+      CHANGE_T0_S_MODE(a1)                                                  # changes mode M to S and set the MEPC
+    #else
+      CHANGE_T0_U_MODE(a1)                                                  # changes mode M to U and set the MEPC
+    #endif
 
 
 check_execute:
-    li t1, 0x45                                                             # page fault should raise 
    
-    la a1, rvtest_data
-    lw t1,8(a1)
-    bne t1, x0,exit 
-    sw t4,8(a1)
+    li t1, 0x45                                                             # page fault should raise 
+    j exit
 
+trap_handler:
 
-PTE_LEVEL1_USER:
+    csrr t0, mcause                                                         # read the value of mcause 
+    la t1, rvtest_check                                                     # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                            # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                            # load the expected value of mepc 
+    lw t4, 8(t1)                                                            # load the expected value of mcause  
 
-# ----------------LEVEL 1 PTE Setup for load and store test------------
+    li  t1, CAUSE_SUPERVISOR_ECALL                                          # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                    # checks if ecall is occured
 
-    la a1,vm_en                                                             # loads the address of label vm_en
-    mv a0, a1                                                               # generrates the VA for label vm_en
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+    li  t1, CAUSE_USER_ECALL                                                # load the value of user ecall
+    beq t0,t1,next_instr                                                    # checks for ecall is occured
+
+    beqz t2, exit                                                           # Jumps to exit if cause is not expected
  
-    la a1,rvtest_data                                                       # loads the address of label rvtest_data
-    mv a0, a1                                                               # generrates the VA for label rvtest_data
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                          # setup the PTE for level1   
+    csrr t5,mepc                                                            # read the value of mepc 
+    bne t3,t5,exit                                                          # check the value of mepc with it's expected value
 
-    la a1,rvtest_check                                                      # loads the address of label rvtest_data
-    mv a0, a1                                                               # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V)    # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+    bne  t0, t4, exit                                                       # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
 
-# ----------------Set the SATP and change the mode---------------------
+    li t5, CAUSE_FETCH_PAGE_FAULT                                           # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                    # if fetch page fault jump to next instr in M mode
 
 
-    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
-    la a1,vm_en                                                             # loads the address of vm_en 
-    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC value to a1
+continue_execution:
 
+    INCREMENT_MEPC  _SUMODE_                                                # update the value of mepc 
+    mret                                                                    # return 
+
+next_instr:
+
+    INCREMENT_MEPC  _MMODE_                                                 # update the value of mepc 
+    li t1,MSTATUS_MPP                                                       # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                         # update the value mstatus MPP 
+    mret                                                                    # return 
 
 
 RVTEST_EXIT_LOGIC                                                           # Exit logic 
 
 .data  
-.align 24
+.align 24                                                                   # Superpage align  
     rvtest_check: 
-
-        .word 0xdeadbeef                                                    # 1 for cause expected 0  for no cause 
-        .word 0xbeefdead                                                    # write the value of mepc here (where  cause is expected)
-        .word 0xcafecafe                                                    # write the value of expect cause 
+      .word 0xdeadbeef                                                      # 1 for cause expected 0  for no cause 
+      .word 0xbeefdead                                                      # write the value of mepc here (where  cause is expected)
+      .word 0xcafecafe                                                      # write the value of expect cause 
 .align 22                                     
     rvtest_data:   
-        .word 0xbeefcafe                                                 
-        .word 0xdeadcafe                                                 
-        .word 0x00000000                                                 
-        .word 0x00000000 
+      .word 0xbeefcafe                                                 
+      .word 0xdeadcafe                                                 
+      .word 0x00000000                                                 
+      .word 0x00000000 
 .align 12                                                      
     pgtb_l1:                                                       
         .zero 4096                                                 

--- a/cva6/tests/custom/sv32/vm_invalid_pte01.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte01.S
@@ -1,0 +1,236 @@
+#=======================================================================
+#   🌟 In-Valid Permission of Level1 PTE 🌟
+#-----------------------------------------------------------------------
+# Test Description:
+#
+# If PTE does not have the Valid (pte.V=0) permission, accessing it
+# would raise a page fault exception of the corresponding access type.
+# When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, this test
+# covers the following scenarios in both supervisor and user privilege
+# modes for level1 PTE.
+#
+# 💫 Set PTE.V = 0 and test the read access.
+# 💫 Set PTE.V = 0 and test the write access.
+# 💫 Set PTE.V = 0 and test the execute access.
+#
+#=======================================================================
+
+#include "macros.h"
+
+trap_handler:
+
+    csrr t0, mcause                                                        # read the value of mcause 
+    la t1, rvtest_check                                                    # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                           # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                           # load the expected value of mepc 
+    lw t4, 8(t1)                                                           # load the expected value of mcause  
+
+    li  t1, CAUSE_SUPERVISOR_ECALL                                         # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                   # checks if ecall is occured
+
+    li  t1, CAUSE_USER_ECALL                                               # load the value of user ecall
+    beq t0,t1,next_instr                                                   # checks for ecall is occured
+
+    beqz t2, exit                                                          # Jumps to exit if cause is not expected
+ 
+    csrr t5,mepc                                                           # read the value of mepc 
+    bne t3,t5,exit                                                         # check the value of mepc with it's expected value
+
+    bne  t0, t4, exit                                                      # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
+
+    li t5, CAUSE_FETCH_ACCESS                                              # load the value of fetch access fault
+    beq t0, t5, next_instr                                                 # if fetch access fault jump to next instr in M mode  
+
+    li t5, CAUSE_FETCH_PAGE_FAULT                                          # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                   # if fetch page fault jump to next instr in M mode
+
+
+continue_execution:
+
+    INCREMENT_MEPC                                                         # update the value of mepc 
+    mret
+
+next_instr:
+
+    INCREMENT_MEPC                                                         # update the value of mepc 
+    li t1,MSTATUS_MPP                                                      # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                        # update the value mstatus MPP 
+    mret
+
+.text
+.global _start
+
+_start:
+    ALL_MEM_PMP                                                            # PMP permission to all the mem
+    la t1,trap_handler                                                     # loads the address of trap handler 
+    csrw mtvec,t1                                                          # sets the mtvec to trap handler 
+    
+PTE_LEVEL1_SUPERVISOR:
+
+# ----------------LEVEL 1 PTE Setup for load and store test------------
+
+    la a1,vm_en                                                            # loads the address of label vm_en
+    mv a0, a1                                                              # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )          # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+ 
+    la a1,rvtest_data                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                              # generrates the VA for label rvtest_data
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1   
+
+    la a1,rvtest_check                                                     # loads the address of label rvtest_data
+    mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
+    ori a2, x0, ( PTE_W | PTE_R | PTE_V )                                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+
+    SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
+    la a1,vm_en                                                            # loads the address of vm_en 
+    CHANGE_T0_S_MODE(a1)                                                   # changes mode M to S and set the MEPC value to a1
+
+# ----------------Virtualization Enabeled------------------------------
+
+vm_en:
+
+    li t1,10
+pre_load:
+
+    la t1, rvtest_check
+    la t2, check_load
+    li t3, CAUSE_LOAD_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1, rvtest_data                                                      # loads the address of label rvtest_data
+
+check_load:
+
+    lw t1,0(a1)  
+    nop
+
+pre_store:
+
+    la t1, rvtest_check
+    la t2, check_store
+    li t3, CAUSE_STORE_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+check_store:
+    sw t1,0(a1)
+    nop                          
+    ecall
+
+pre_execute:
+
+    la t1, rvtest_check
+    la t2, check_execute
+    li t3, CAUSE_FETCH_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+    lw t1,12(a1)
+    bne t1, x0,PTE_LEVEL1_USER_EXECUTE 
+    sw t4,12(a1)
+    
+PTE_LEVEL1_SUPERVISOR_EXECUTE:
+
+# -------------LEVEL 1 PTE Setup for execute test----------------------
+                                                                            # Setup a new PTE to test execute 
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1 
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    CHANGE_T0_S_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+
+PTE_LEVEL1_USER_EXECUTE:
+
+# -------------LEVEL 1 PTE Setup for execute test----------------------
+                                                                            # Setup a new PTE to test execute 
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1 
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+
+
+check_execute:
+    li t1, 0x45                                                             # page fault should raise 
+
+    addi s11,s11,1
+    li t1,1
+    beq s11,t1,PTE_LEVEL1_USER
+    j exit
+
+PTE_LEVEL1_USER:
+
+# ----------------LEVEL 1 PTE Setup for load and store test------------
+
+    la a1,vm_en                                                             # loads the address of label vm_en
+    mv a0, a1                                                               # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+ 
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+    mv a0, a1                                                               # generrates the VA for label rvtest_data
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                          # setup the PTE for level1   
+
+    la a1,rvtest_check                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                               # generrates the VA for label rvtest_data                                          
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V)    # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,vm_en                                                             # loads the address of vm_en 
+    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC value to a1
+
+
+
+RVTEST_EXIT_LOGIC                                                           # Exit logic 
+
+.data  
+.align 24
+    rvtest_check: 
+
+        .word 0xdeadbeef                                                    # 1 for cause expected 0  for no cause 
+        .word 0xbeefdead                                                    # write the value of mepc here (where  cause is expected)
+        .word 0xcafecafe                                                    # write the value of expect cause 
+.align 22                                     
+    rvtest_data:   
+        .word 0xbeefcafe                                                 
+        .word 0xdeadcafe                                                 
+        .word 0xcafecafe                                                 
+        .word 0x00000000 
+.align 12                                                      
+    pgtb_l1:                                                       
+        .zero 4096                                                 
+    pgtb_l0:                                                       
+        .zero 4096                                                                                                     
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/sv32/vm_invalid_pte02.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte02.S
@@ -62,6 +62,7 @@ next_instr:
 .global _start
 
 _start:
+
     ALL_MEM_PMP                                                            # PMP permission to all the mem
     la t1,trap_handler                                                     # loads the address of trap handler 
     csrw mtvec,t1                                                          # sets the mtvec to trap handler 
@@ -69,6 +70,7 @@ _start:
 PTE_LEVEL1_SUPERVISOR:
 
 # ----------------LEVEL 1 PTE Setup for load and store test-------------
+
     la a1,pgtb_l0                                                          # loads the address of label vm_en
     mv a0, a1                                                              # generrates the VA for label vm_en
     ori a2, x0, ( PTE_V )                                                  # sets the permission bits
@@ -86,7 +88,7 @@ PTE_LEVEL1_SUPERVISOR:
 
     la a1,rvtest_check                                                     # loads the address of label rvtest_data
     mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V)           # sets the permission bits
+    ori a2, x0, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V)                   # sets the permission bits
     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
 
 # ----------------Set the SATP and change the mode---------------------
@@ -101,6 +103,7 @@ PTE_LEVEL1_SUPERVISOR:
 vm_en:
 
     li t1,10
+
 pre_load:
 
     la t1, rvtest_check
@@ -129,6 +132,7 @@ pre_store:
     la a1,rvtest_data                                                       # loads the address of label rvtest_data
 
 check_store:
+
     sw t1,0(a1)
     nop                          
     ecall
@@ -182,10 +186,10 @@ PTE_LEVEL1_USER_EXECUTE:
 check_execute:
     li t1, 0x45                                                             # page fault should raise 
 
-    addi s11,s11,1
-    li t1,1
-    beq s11,t1,PTE_LEVEL1_USER
-    j exit
+    la a1, rvtest_data
+    lw t1,8(a1)
+    bne t1,x0,exit 
+    sw t4,8(a1)
 
 PTE_LEVEL1_USER:
 
@@ -203,7 +207,7 @@ PTE_LEVEL1_USER:
 
     la a1,rvtest_check                                                      # loads the address of label rvtest_data
     mv a0, a1                                                               # generrates the VA for label rvtest_data                                          
-    ori a2, x0, (PTE_W | PTE_R | PTE_V )                                    # sets the permission bits
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V )                                    # sets the permission bits
     PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
 
 # ----------------Set the SATP and change the mode------------------------
@@ -227,7 +231,7 @@ RVTEST_EXIT_LOGIC                                                           # Ex
     rvtest_data:   
         .word 0xbeefcafe                                                 
         .word 0xdeadcafe                                                 
-        .word 0xcafecafe                                                 
+        .word 0x00000000                                                 
         .word 0x00000000 
 .align 12                                                      
     pgtb_l1:                                                       

--- a/cva6/tests/custom/sv32/vm_invalid_pte02.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte02.S
@@ -1,5 +1,6 @@
 #=======================================================================
-#   🌟 In-Valid Permission of Level0 PTE 🌟
+#   🌟 RWX Access of Level0 PTE in User and Supervisor mode when valid
+#      bit is low  🌟
 #-----------------------------------------------------------------------
 # Test Description:
 #
@@ -7,7 +8,7 @@
 # would raise a page fault exception of the corresponding access type.
 # When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, this test
 # covers the following scenarios in both supervisor and user privilege
-# modes for level0 PTE.
+# modes for level1 PTE.
 #
 # 💫 Set PTE.V = 0 and test the read access.
 # 💫 Set PTE.V = 0 and test the write access.
@@ -15,224 +16,160 @@
 #
 #=======================================================================
 
-
 #include "macros.h"
 
-trap_handler:
-
-    csrr t0, mcause                                                        # read the value of mcause 
-    la t1, rvtest_check                                                    # load the address of trvtest_check
-    
-    lw t2, 0(t1)                                                           # if cause expected then load 1 else 0
-    lw t3, 4(t1)                                                           # load the expected value of mepc 
-    lw t4, 8(t1)                                                           # load the expected value of mcause  
-
-    li  t1, CAUSE_SUPERVISOR_ECALL                                         # load the value of supervisor ecall
-    beq t0,t1,next_instr                                                   # checks if ecall is occured
-
-    li  t1, CAUSE_USER_ECALL                                               # load the value of user ecall
-    beq t0,t1,next_instr                                                   # checks for ecall is occured
-
-    beqz t2, exit                                                          # Jumps to exit if cause is not expected
- 
-    csrr t5,mepc                                                           # read the value of mepc 
-    bne t3,t5,exit                                                         # check the value of mepc with it's expected value
-
-    bne  t0, t4, exit                                                      # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
-
-    li t5, CAUSE_FETCH_ACCESS                                              # load the value of fetch access fault
-    beq t0, t5, next_instr                                                 # if fetch access fault jump to next instr in M mode  
-
-    li t5, CAUSE_FETCH_PAGE_FAULT                                          # load the value of fetch page fault exception 
-    beq t0,t5,next_instr                                                   # if fetch page fault jump to next instr in M mode
-
-continue_execution:
-
-    INCREMENT_MEPC                                                         # update the value of mepc 
-    mret
-
-next_instr:
-
-    INCREMENT_MEPC                                                         # update the value of mepc 
-    li t1,MSTATUS_MPP                                                      # update the MPP to MSTATUS_MPP for M mode
-    csrs mstatus,t1                                                        # update the value mstatus MPP 
-    mret
+#ifdef smode
+    #define SET_PTE_U 0
+#else
+    #define SET_PTE_U PTE_U
+#endif
 
 .text
 .global _start
 
 _start:
-
-    ALL_MEM_PMP                                                            # PMP permission to all the mem
+    ALL_MEM_PMP                                                            # PMP permission to all the memory
     la t1,trap_handler                                                     # loads the address of trap handler 
     csrw mtvec,t1                                                          # sets the mtvec to trap handler 
-    
-PTE_LEVEL1_SUPERVISOR:
 
-# ----------------LEVEL 1 PTE Setup for load and store test-------------
-
+# ----------------LEVEL1 PTE Setup to point to LEVEL0 PTE----------------
     la a1,pgtb_l0                                                          # loads the address of label vm_en
     mv a0, a1                                                              # generrates the VA for label vm_en
     ori a2, x0, ( PTE_V )                                                  # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1
 
+# ----------------LEVEL 0 PTE Setup for load and store test--------------
     la a1,vm_en                                                            # loads the address of label vm_en
-    mv a0, a1                                                              # generrates the VA for label vm_en
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )          # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
-    
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_V )              # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
+ 
     la a1,rvtest_data                                                      # loads the address of label rvtest_data
-    mv a0, a1                                                              # generrates the VA for label rvtest_data
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                  # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1  
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_W | PTE_R )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
 
     la a1,rvtest_check                                                     # loads the address of label rvtest_data
-    mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_D | PTE_A | PTE_W | PTE_R | PTE_V)                   # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
+    mv a0, a1                                                              # set the VA to PA (identity mapping)                                          
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_W | PTE_R | PTE_V )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
 
-# ----------------Set the SATP and change the mode---------------------
-
+# ----------------Set the SATP and change the mode-----------------------
 
     SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
-    la a1,vm_en                                                            # loads the address of vm_en 
-    CHANGE_T0_S_MODE(a1)                                                   # changes mode M to S and set the MEPC value to a1
+    la a1,vm_en                                                            # loads the address of vm_en
+    #ifdef smode																													 
+        CHANGE_T0_S_MODE(a1)                                        	   # changes mode M to S and set the MEPC value to a1
+    #else
+        CHANGE_T0_U_MODE(a1)                                        	   # changes mode M to U and set the MEPC value to a1
+    #endif
 
-# ----------------Virtualization Enabeled------------------------------
+# ----------------Virtualization Enabeled-------------------------------
 
 vm_en:
 
-    li t1,10
-
+    li t1,10                                                               
+    
 pre_load:
 
-    la t1, rvtest_check
-    la t2, check_load
-    li t3, CAUSE_LOAD_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    TEST_PROLOG(check_load,CAUSE_LOAD_PAGE_FAULT)                           # load the addr and expected cause 
     la a1, rvtest_data                                                      # loads the address of label rvtest_data
 
 check_load:
 
-    lw t1,0(a1)  
+    lw t1,0(a1)                                                             # tests the load access 
     nop
 
 pre_store:
 
-    la t1, rvtest_check
-    la t2, check_store
-    li t3, CAUSE_STORE_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    TEST_PROLOG(check_store,CAUSE_STORE_PAGE_FAULT)                         # load the addr and expected cause 
     la a1,rvtest_data                                                       # loads the address of label rvtest_data
 
 check_store:
-
-    sw t1,0(a1)
+    sw t1,0(a1)                                                             # test the store access
     nop                          
-    ecall
+    SMODE_ECALL
 
 pre_execute:
 
-    la t1, rvtest_check
-    la t2, check_execute
-    li t3, CAUSE_FETCH_PAGE_FAULT
-    li t4, 1    
-    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
-    sw t2, 4(t1)                                                            # store the address where cause is expected 
-    sw t3, 8(t1)                                                            # store the mcause value of expected cause
-    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+    TEST_PROLOG(check_execute,CAUSE_FETCH_PAGE_FAULT)                       # load the addr and expected cause 
 
-    lw t1,12(a1)
-    bne t1, x0,PTE_LEVEL1_USER_EXECUTE 
-    sw t4,12(a1)
-    
-PTE_LEVEL1_SUPERVISOR_EXECUTE:
-
-# -------------LEVEL 1 PTE Setup for execute test-----------------------
-                                                                            # Setup a new PTE to test execute 
+# -------------LEVEL 1 PTE Setup for execute test------------------------
+                                                                            # Setup a new PTE to test execute
     la a1,check_execute                                                     # loads the address of label vm_en
-    mv a0, a1 
-    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                   # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+    mv a0, a1                                                               # VA = PA - Identity Map
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X )                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                         # setup the PTE for level0
 
-# ----------------Set the SATP and change the mode----------------------
+# ----------------Set the SATP and change the mode---------------------
 
     SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
     la a1,check_execute                                                     # loads the address of check_execute
-    CHANGE_T0_S_MODE(a1)                                                    # changes mode M to S and set the MEPC 
-
-PTE_LEVEL1_USER_EXECUTE:
-
-# -------------LEVEL 1 PTE Setup for execute test-----------------------
-                                                                            # Setup a new PTE to test execute 
-    la a1,check_execute                                                     # loads the address of label vm_en
-    mv a0, a1 
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
-
-# ----------------Set the SATP and change the mode----------------------
-
-    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
-    la a1,check_execute                                                     # loads the address of check_execute
-    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+    #ifdef smode
+      CHANGE_T0_S_MODE(a1)                                                  # changes mode M to S and set the MEPC
+    #else
+      CHANGE_T0_U_MODE(a1)                                                  # changes mode M to U and set the MEPC
+    #endif
 
 
 check_execute:
+   
     li t1, 0x45                                                             # page fault should raise 
+    j exit
 
-    la a1, rvtest_data
-    lw t1,8(a1)
-    bne t1,x0,exit 
-    sw t4,8(a1)
+trap_handler:
 
-PTE_LEVEL1_USER:
+    csrr t0, mcause                                                         # read the value of mcause 
+    la t1, rvtest_check                                                     # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                            # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                            # load the expected value of mepc 
+    lw t4, 8(t1)                                                            # load the expected value of mcause  
 
-# ----------------LEVEL 1 PTE Setup for load and store test--------------
+    li  t1, CAUSE_SUPERVISOR_ECALL                                          # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                    # checks if ecall is occured
 
-    la a1,vm_en                                                             # loads the address of label vm_en
-    mv a0, a1                                                               # generrates the VA for label vm_en
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+    li  t1, CAUSE_USER_ECALL                                                # load the value of user ecall
+    beq t0,t1,next_instr                                                    # checks for ecall is occured
+
+    beqz t2, exit                                                           # Jumps to exit if cause is not expected
  
-    la a1,rvtest_data                                                       # loads the address of label rvtest_data
-    mv a0, a1                                                               # generrates the VA for label rvtest_data
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                          # setup the PTE for level1   
+    csrr t5,mepc                                                            # read the value of mepc 
+    bne t3,t5,exit                                                          # check the value of mepc with it's expected value
 
-    la a1,rvtest_check                                                      # loads the address of label rvtest_data
-    mv a0, a1                                                               # generrates the VA for label rvtest_data                                          
-    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_W | PTE_R | PTE_V )                                    # sets the permission bits
-    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+    bne  t0, t4, exit                                                       # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
 
-# ----------------Set the SATP and change the mode------------------------
+    li t5, CAUSE_FETCH_PAGE_FAULT                                           # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                    # if fetch page fault jump to next instr in M mode
 
 
-    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
-    la a1,vm_en                                                             # loads the address of vm_en 
-    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC value to a1
+continue_execution:
 
+    INCREMENT_MEPC                                                          # update the value of mepc 
+    mret                                                                    # return 
+
+next_instr:
+
+    INCREMENT_MEPC                                                          # update the value of mepc 
+    li t1,MSTATUS_MPP                                                       # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                         # update the value mstatus MPP 
+    mret                                                                    # return 
 
 
 RVTEST_EXIT_LOGIC                                                           # Exit logic 
 
 .data  
+.align                                                                     
     rvtest_check: 
-
-        .word 0xdeadbeef                                                    # 1 for cause expected 0  for no cause 
-        .word 0xbeefdead                                                    # write the value of mepc here (where  cause is expected)
-        .word 0xcafecafe                                                    # write the value of expect cause 
+      .word 0xdeadbeef                                                      # 1 for cause expected 0  for no cause 
+      .word 0xbeefdead                                                      # write the value of mepc here (where  cause is expected)
+      .word 0xcafecafe                                                      # write the value of expect cause 
 .align 12                                     
     rvtest_data:   
-        .word 0xbeefcafe                                                 
-        .word 0xdeadcafe                                                 
-        .word 0x00000000                                                 
-        .word 0x00000000 
+      .word 0xbeefcafe                                                 
+      .word 0xdeadcafe                                                 
+      .word 0x00000000                                                 
+      .word 0x00000000 
 .align 12                                                      
     pgtb_l1:                                                       
         .zero 4096                                                 

--- a/cva6/tests/custom/sv32/vm_invalid_pte02.S
+++ b/cva6/tests/custom/sv32/vm_invalid_pte02.S
@@ -1,0 +1,239 @@
+#=======================================================================
+#   🌟 In-Valid Permission of Level0 PTE 🌟
+#-----------------------------------------------------------------------
+# Test Description:
+#
+# If PTE does not have the Valid (pte.V=0) permission, accessing it
+# would raise a page fault exception of the corresponding access type.
+# When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, this test
+# covers the following scenarios in both supervisor and user privilege
+# modes for level0 PTE.
+#
+# 💫 Set PTE.V = 0 and test the read access.
+# 💫 Set PTE.V = 0 and test the write access.
+# 💫 Set PTE.V = 0 and test the execute access.
+#
+#=======================================================================
+
+
+#include "macros.h"
+
+trap_handler:
+
+    csrr t0, mcause                                                        # read the value of mcause 
+    la t1, rvtest_check                                                    # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                           # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                           # load the expected value of mepc 
+    lw t4, 8(t1)                                                           # load the expected value of mcause  
+
+    li  t1, CAUSE_SUPERVISOR_ECALL                                         # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                   # checks if ecall is occured
+
+    li  t1, CAUSE_USER_ECALL                                               # load the value of user ecall
+    beq t0,t1,next_instr                                                   # checks for ecall is occured
+
+    beqz t2, exit                                                          # Jumps to exit if cause is not expected
+ 
+    csrr t5,mepc                                                           # read the value of mepc 
+    bne t3,t5,exit                                                         # check the value of mepc with it's expected value
+
+    bne  t0, t4, exit                                                      # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
+
+    li t5, CAUSE_FETCH_ACCESS                                              # load the value of fetch access fault
+    beq t0, t5, next_instr                                                 # if fetch access fault jump to next instr in M mode  
+
+    li t5, CAUSE_FETCH_PAGE_FAULT                                          # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                   # if fetch page fault jump to next instr in M mode
+
+continue_execution:
+
+    INCREMENT_MEPC                                                         # update the value of mepc 
+    mret
+
+next_instr:
+
+    INCREMENT_MEPC                                                         # update the value of mepc 
+    li t1,MSTATUS_MPP                                                      # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                        # update the value mstatus MPP 
+    mret
+
+.text
+.global _start
+
+_start:
+    ALL_MEM_PMP                                                            # PMP permission to all the mem
+    la t1,trap_handler                                                     # loads the address of trap handler 
+    csrw mtvec,t1                                                          # sets the mtvec to trap handler 
+    
+PTE_LEVEL1_SUPERVISOR:
+
+# ----------------LEVEL 1 PTE Setup for load and store test-------------
+    la a1,pgtb_l0                                                          # loads the address of label vm_en
+    mv a0, a1                                                              # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_V )                                                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL1)                                 # setup the PTE for level1
+
+    la a1,vm_en                                                            # loads the address of label vm_en
+    mv a0, a1                                                              # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V )          # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
+    
+    la a1,rvtest_data                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                              # generrates the VA for label rvtest_data
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1  
+
+    la a1,rvtest_check                                                     # loads the address of label rvtest_data
+    mv a0, a1                                                              # generrates the VA for label rvtest_data                                          
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R | PTE_V)           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                 # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+
+    SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
+    la a1,vm_en                                                            # loads the address of vm_en 
+    CHANGE_T0_S_MODE(a1)                                                   # changes mode M to S and set the MEPC value to a1
+
+# ----------------Virtualization Enabeled------------------------------
+
+vm_en:
+
+    li t1,10
+pre_load:
+
+    la t1, rvtest_check
+    la t2, check_load
+    li t3, CAUSE_LOAD_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1, rvtest_data                                                      # loads the address of label rvtest_data
+
+check_load:
+
+    lw t1,0(a1)  
+    nop
+
+pre_store:
+
+    la t1, rvtest_check
+    la t2, check_store
+    li t3, CAUSE_STORE_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+check_store:
+    sw t1,0(a1)
+    nop                          
+    ecall
+
+pre_execute:
+
+    la t1, rvtest_check
+    la t2, check_execute
+    li t3, CAUSE_FETCH_PAGE_FAULT
+    li t4, 1    
+    sw t4, 0(t1)                                                            # store 1 to indicate cause is expected   
+    sw t2, 4(t1)                                                            # store the address where cause is expected 
+    sw t3, 8(t1)                                                            # store the mcause value of expected cause
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+    lw t1,12(a1)
+    bne t1, x0,PTE_LEVEL1_USER_EXECUTE 
+    sw t4,12(a1)
+    
+PTE_LEVEL1_SUPERVISOR_EXECUTE:
+
+# -------------LEVEL 1 PTE Setup for execute test-----------------------
+                                                                            # Setup a new PTE to test execute 
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1 
+    ori a2, x0, ( PTE_D | PTE_A | PTE_X | PTE_W | PTE_R )                   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode----------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    CHANGE_T0_S_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+
+PTE_LEVEL1_USER_EXECUTE:
+
+# -------------LEVEL 1 PTE Setup for execute test-----------------------
+                                                                            # Setup a new PTE to test execute 
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1 
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode----------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC 
+
+
+check_execute:
+    li t1, 0x45                                                             # page fault should raise 
+
+    addi s11,s11,1
+    li t1,1
+    beq s11,t1,PTE_LEVEL1_USER
+    j exit
+
+PTE_LEVEL1_USER:
+
+# ----------------LEVEL 1 PTE Setup for load and store test--------------
+
+    la a1,vm_en                                                             # loads the address of label vm_en
+    mv a0, a1                                                               # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R | PTE_V )   # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+ 
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+    mv a0, a1                                                               # generrates the VA for label rvtest_data
+    ori a2, x0, ( PTE_D | PTE_A | PTE_U | PTE_X | PTE_W | PTE_R )           # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                          # setup the PTE for level1   
+
+    la a1,rvtest_check                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                               # generrates the VA for label rvtest_data                                          
+    ori a2, x0, (PTE_W | PTE_R | PTE_V )                                    # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, LEVEL0)                                  # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode------------------------
+
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,vm_en                                                             # loads the address of vm_en 
+    CHANGE_T0_U_MODE(a1)                                                    # changes mode M to S and set the MEPC value to a1
+
+
+
+RVTEST_EXIT_LOGIC                                                           # Exit logic 
+
+.data  
+    rvtest_check: 
+
+        .word 0xdeadbeef                                                    # 1 for cause expected 0  for no cause 
+        .word 0xbeefdead                                                    # write the value of mepc here (where  cause is expected)
+        .word 0xcafecafe                                                    # write the value of expect cause 
+.align 12                                     
+    rvtest_data:   
+        .word 0xbeefcafe                                                 
+        .word 0xdeadcafe                                                 
+        .word 0xcafecafe                                                 
+        .word 0x00000000 
+.align 12                                                      
+    pgtb_l1:                                                       
+        .zero 4096                                                 
+    pgtb_l0:                                                       
+        .zero 4096                                                                                                     
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;


### PR DESCRIPTION
## [Test for In-Valid Permission of PTE](https://github.com/10x-Engineers/core-v-verif/commit/7c64a5e0d491bcfd79480a5e6e79329717c9719f)

I've added a new test case to cover scenarios involving invalid permissions of Page Table Entries (PTEs). When a PTE does not have valid permission (pte.V=0), attempting to access it will result in a page fault exception of the corresponding access type.

The test cases are specifically designed for situations when satp.mode=sv32 and the PTE has (r,w,x) PMP (Physical Memory Protection) permissions. The following tests have been implemented and executed in both supervisor and user privilege modes for both level0 and level1 PTEs:

1. Set PTE.V = 0 and test read access.
2. Set PTE.V = 0 and test write access.
3. Set PTE.V = 0 and test execute access.

Please review the changes and let me know if any further adjustments or additions are needed. Your feedback is highly appreciated!

#### Files and their purpose:

|   **`File Name`**   	|  **`Mode`**  	| **`Level`** 	| **`Testing For`** 	| 
|:------------------------:|:------------------:|:-----------------:|:-------------------------:|
| **[vm_invalid_pte_01.S](https://github.com/10x-Engineers/core-v-verif/commit/7c64a5e0d491bcfd79480a5e6e79329717c9719f#diff-0991314869b74f1c72af5ab5e76a18d9c0797f6fde686022929d829b12d8c627)** 	|   Supervisor /User	|     1     	|        RWX Access  	|
| **[vm_invalid_pte_02.S](https://github.com/10x-Engineers/core-v-verif/commit/7c64a5e0d491bcfd79480a5e6e79329717c9719f#diff-19c617b9cb785b72e3150661baf455ffb52862e7a98e43ad6b3d2667c0f5db9c)** 	|   Supervisor /User	|     0    	|    	 RWX Access     	|   