### PR TITLE
SV32-DV Plan Execution - core-v-verif

### DIFF
--- a/cva6/regress/dv-riscv-arch-test.sh
+++ b/cva6/regress/dv-riscv-arch-test.sh
@@ -19,7 +19,7 @@ source ./cva6/regress/install-riscv-dv.sh
 source ./cva6/regress/install-riscv-arch-test.sh
 
 if ! [ -n "$DV_TARGET" ]; then
-  DV_TARGET=cv64a6_imafdc_sv39
+  DV_TARGET=cv32a60x
 fi
 
 if ! [ -n "$DV_SIMULATORS" ]; then
@@ -27,5 +27,5 @@ if ! [ -n "$DV_SIMULATORS" ]; then
 fi
 
 cd cva6/sim
-python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
+python3 cva6.py --testlist=../tests/testlist_riscv-mmu-$DV_TARGET.yaml --target $DV_TARGET --iss_yaml=cva6.yaml --iss=$DV_SIMULATORS $DV_OPTS --linker=../tests/riscv-arch-test/riscv-target/spike/link.ld
 cd -

--- a/cva6/tests/custom/macros.h
+++ b/cva6/tests/custom/macros.h
@@ -1,0 +1,101 @@
+#include "env/encoding.h"
+
+#define _start   rvtest_entry_point                            
+#define SMODE_ECALL ecall
+#define UMODE_ECALL ecall
+
+#define LEVEL0 0x00
+#define LEVEL1 0x01
+
+#define SUPERPAGE_SHIFT 22
+
+#define PTE(PA, PR)                                                ;\
+    srli     PA, PA, RISCV_PGSHIFT                                 ;\
+    slli     PA, PA, PTE_PPN_SHIFT                                 ;\
+    or       PA, PA, PR                                            ;
+
+#define PTE_SETUP_RV32(PA, PR, TMP, VA, PGTB_ADDR,LEVEL)           ;\
+    PTE(PA, PR)                                                    ;\
+    .if (LEVEL==1)                                                 ;\
+        la   TMP, PGTB_ADDR                                        ;\
+        srli VA,  VA, SUPERPAGE_SHIFT                              ;\
+    .endif                                                         ;\
+    .if (LEVEL==0)                                                 ;\
+        la   TMP, PGTB_ADDR                                        ;\
+        slli VA,  VA, PTE_PPN_SHIFT                                ;\
+        srli VA,  VA, SUPERPAGE_SHIFT                              ;\
+    .endif                                                         ;\
+    slli     VA,  VA,  2                                           ;\
+    add      TMP, TMP, VA                                          ;\
+    sw     PA,  0(TMP)                                             ;
+
+#define SATP_SETUP_SV32(PGTB_ADDR)                                 ;\
+    la   t6,   PGTB_ADDR                                           ;\
+    li   t5,   SATP32_MODE                                         ;\
+    srli t6,   t6, RISCV_PGSHIFT                                   ;\
+    or   t6,   t6, t5                                              ;\
+    csrw satp, t6                                                  ;\
+    sfence.vma                                                     ;
+
+#define CHANGE_T0_S_MODE(MEPC_ADDR)                                ;\
+    li        t0, MSTATUS_MPP                                      ;\
+    csrc mstatus, t0                                               ;\
+    li  t1, MSTATUS_MPP & ( MSTATUS_MPP >> 1)                      ;\
+    csrs mstatus, t1                                               ;\
+    csrw mepc, MEPC_ADDR                                           ;\
+    mret                                                           ;
+
+#define CHANGE_T0_U_MODE(MEPC_ADDR)                                ;\
+    li        t0, MSTATUS_MPP                                      ;\
+    csrc mstatus, t0                                               ;\
+    csrw mepc, MEPC_ADDR                                           ;\
+    mret                                                           ;
+
+
+#define RVTEST_EXIT_LOGIC                                          ;\
+exit:                                                              ;\
+    la t0, tohost                                                  ;\
+    li t1, 1                                                       ;\
+    sw t1, 0(t0)                                                   ;\
+    j exit                                                         ;
+
+#define COREV_VERIF_EXIT_LOGIC                                     ;\
+exit:                                                              ;\
+    slli x1, x1, 1                                                 ;\
+    addi x1, x1, 1                                                 ;\
+    mv x30, s1                                                     ;\
+    sw x1, tohost, x30                                             ;\
+    self_loop: j self_loop                                         ;
+
+#define ALL_MEM_PMP                                                ;\
+    li t2, -1		                                           ;\
+    csrw pmpaddr0, t2                                              ;\
+    li t2, 0x0F		                                           ;\
+    csrw pmpcfg0, t2                                               ;\
+    sfence.vma                                                     ;
+
+#define TEST_PROLOG(ADDR,CAUSE)                                    ;\
+    la t1, rvtest_check                                            ;\
+    la t2, ADDR                                                    ;\
+    li t3, CAUSE                                                   ;\
+    li t4, 1                                                       ;\
+    sw t4, 0(t1)                                                   ;\
+    sw t2, 4(t1)                                                   ;\
+    sw t3, 8(t1)                                                   ;\
+    la a1,rvtest_data                                              ; 
+
+.macro INCREMENT_MEPC label_suffix                                 ;\
+    csrr t1, mepc                                                  ;\
+    lw t5, 0(t1)                                                   ;\
+    li t2, 3                                                       ;\
+    and t2, t2, t5                                                 ;\
+    li t3, 3                                                       ;\
+    bne t2, t3, not_32_bit_Instr_\label_suffix                     ;\
+    addi t1, t1, 4                                                 ;\
+    j write_mepc_\label_suffix                                     ;\
+    not_32_bit_Instr_\label_suffix:                                ;\
+    addi t1, t1, 2                                                 ;\
+    write_mepc_\label_suffix:                                      ;\
+    csrw mepc, t1                                                  ;\
+.endm                                                              ;
+

--- a/cva6/tests/custom/vm_invalid_pte01.S
+++ b/cva6/tests/custom/vm_invalid_pte01.S
@@ -1,0 +1,178 @@
+#=======================================================================
+#   🌟 RWX Access of Level1 PTE in User and Supervisor mode when valid
+#      bit is low  🌟
+#-----------------------------------------------------------------------
+# Test Description:
+#
+# If PTE does not have the Valid (pte.V=0) permission, accessing it
+# would raise a page fault exception of the corresponding access type.
+# When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, this test
+# covers the following scenarios in both supervisor and user privilege
+# modes for level1 PTE.
+#
+# 💫 Set PTE.V = 0 and test the read access.
+# 💫 Set PTE.V = 0 and test the write access.
+# 💫 Set PTE.V = 0 and test the execute access.
+#
+#=======================================================================
+
+#include "macros.h"
+
+#ifdef smode
+    #define SET_PTE_U 0
+#else
+    #define SET_PTE_U PTE_U
+#endif
+
+#define _MMODE_  "M"
+#define _SUMODE_ "SU"
+
+.text
+.global _start
+
+_start:
+    ALL_MEM_PMP                                                            # PMP permission to all the memory
+    la t1,trap_handler                                                     # loads the address of trap handler 
+    csrw mtvec,t1                                                          # sets the mtvec to trap handler 
+    
+# ----------------LEVEL 1 PTE Setup for load and store test------------
+
+    la a1,vm_en                                                            # loads the address of label vm_en
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_V )              # sets the permission bits
+    PTE_SETUP_RV32 ( a1, a2, t1, a0, pgtb_l1, LEVEL1 )                     # setup the PTE for level1
+ 
+    la a1,rvtest_data                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_W | PTE_R )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1   
+
+    la a1,rvtest_check                                                     # loads the address of label rvtest_data
+    mv a0, a1                                                              # set the VA to PA (identity mapping)                                          
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_W | PTE_R | PTE_V )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode----------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
+    la a1,vm_en                                                            # loads the address of vm_en
+    #ifdef smode																													 
+        CHANGE_T0_S_MODE(a1)                                        	   # changes mode M to S and set the MEPC value to a1
+    #else
+        CHANGE_T0_U_MODE(a1)                                        	   # changes mode M to U and set the MEPC value to a1
+    #endif
+
+# ----------------Virtualization Enabeled-------------------------------
+
+vm_en:
+
+    li t1,10                                                               
+    
+pre_load:
+
+    TEST_PROLOG(check_load,CAUSE_LOAD_PAGE_FAULT)                           # load the addr and expected cause 
+    la a1, rvtest_data                                                      # loads the address of label rvtest_data
+
+check_load:
+
+    lw t1,0(a1)                                                             # tests the load access 
+    nop
+
+pre_store:
+
+    TEST_PROLOG(check_store,CAUSE_STORE_PAGE_FAULT)                         # load the addr and expected cause 
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+check_store:
+    sw t1,0(a1)                                                             # test the store access
+    nop                          
+    SMODE_ECALL                                                             # ecall to go to m mode
+
+pre_execute:
+
+    TEST_PROLOG(check_execute,CAUSE_FETCH_PAGE_FAULT)                       # load the addr and expected cause 
+
+# -------------LEVEL 1 PTE Setup for execute test------------------------
+                                                                            # Setup a new PTE to test execute
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1                                                               # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X )                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                         # setup the PTE for level1
+
+# ----------------Set the SATP and change the mode---------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    #ifdef smode
+      CHANGE_T0_S_MODE(a1)                                                  # changes mode M to S and set the MEPC
+    #else
+      CHANGE_T0_U_MODE(a1)                                                  # changes mode M to U and set the MEPC
+    #endif
+
+
+check_execute:
+   
+    li t1, 0x45                                                             # page fault should raise 
+    j exit
+
+trap_handler:
+
+    csrr t0, mcause                                                         # read the value of mcause 
+    la t1, rvtest_check                                                     # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                            # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                            # load the expected value of mepc 
+    lw t4, 8(t1)                                                            # load the expected value of mcause  
+
+    li  t1, CAUSE_SUPERVISOR_ECALL                                          # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                    # checks if ecall is occured
+
+    li  t1, CAUSE_USER_ECALL                                                # load the value of user ecall
+    beq t0,t1,next_instr                                                    # checks for ecall is occured
+
+    beqz t2, exit                                                           # Jumps to exit if cause is not expected
+ 
+    csrr t5,mepc                                                            # read the value of mepc 
+    bne t3,t5,exit                                                          # check the value of mepc with it's expected value
+
+    bne  t0, t4, exit                                                       # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
+
+    li t5, CAUSE_FETCH_PAGE_FAULT                                           # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                    # if fetch page fault jump to next instr in M mode
+
+
+continue_execution:
+
+    INCREMENT_MEPC  _SUMODE_                                                # update the value of mepc 
+    mret                                                                    # return 
+
+next_instr:
+
+    INCREMENT_MEPC  _MMODE_                                                 # update the value of mepc 
+    li t1,MSTATUS_MPP                                                       # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                         # update the value mstatus MPP 
+    mret                                                                    # return 
+
+
+COREV_VERIF_EXIT_LOGIC                                                      # Exit logic 
+
+.data  
+.align 24                                                                   # Superpage align  
+    rvtest_check: 
+      .word 0xdeadbeef                                                      # 1 for cause expected 0  for no cause 
+      .word 0xbeefdead                                                      # write the value of mepc here (where  cause is expected)
+      .word 0xcafecafe                                                      # write the value of expect cause 
+.align 22                                     
+    rvtest_data:   
+      .word 0xbeefcafe                                                 
+      .word 0xdeadcafe                                                 
+      .word 0x00000000                                                 
+      .word 0x00000000 
+.align 12                                                      
+    pgtb_l1:                                                       
+        .zero 4096                                                 
+    pgtb_l0:                                                       
+        .zero 4096                                                                                                     
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/custom/vm_invalid_pte02.S
+++ b/cva6/tests/custom/vm_invalid_pte02.S
@@ -1,0 +1,189 @@
+#=======================================================================
+#   🌟 RWX Access of Level0 PTE in User and Supervisor mode when valid
+#      bit is low  🌟
+#-----------------------------------------------------------------------
+# Test Description:
+#
+# If PTE does not have the Valid (pte.V=0) permission, accessing it
+# would raise a page fault exception of the corresponding access type.
+# When satp.mode=sv32 and PTE has (r,w,x) PMP permissions, this test
+# covers the following scenarios in both supervisor and user privilege
+# modes for level1 PTE.
+#
+# 💫 Set PTE.V = 0 and test the read access.
+# 💫 Set PTE.V = 0 and test the write access.
+# 💫 Set PTE.V = 0 and test the execute access.
+#
+#=======================================================================
+
+#include "macros.h"
+
+#ifdef smode
+    #define SET_PTE_U 0
+#else
+    #define SET_PTE_U PTE_U
+#endif
+
+#define _MMODE_  "M"
+#define _SUMODE_ "SU"
+
+.text
+.global _start
+
+_start:
+    ALL_MEM_PMP                                                            # PMP permission to all the memory
+    la t1,trap_handler                                                     # loads the address of trap handler 
+    csrw mtvec,t1                                                          # sets the mtvec to trap handler 
+
+# ----------------LEVEL1 PTE Setup to point to LEVEL0 PTE----------------
+    la a1,pgtb_l0                                                          # loads the address of label vm_en
+    mv a0, a1                                                              # generrates the VA for label vm_en
+    ori a2, x0, ( PTE_V )                                                  # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l1, LEVEL1)                        # setup the PTE for level1
+
+# ----------------LEVEL 0 PTE Setup for load and store test--------------
+    la a1,vm_en                                                            # loads the address of label vm_en
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_V )              # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
+ 
+    la a1,rvtest_data                                                      # loads the address of label rvtest_data
+    mv a0, a1                                                              # set the VA to PA (identity mapping)
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X | PTE_W | PTE_R )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
+
+    la a1,rvtest_check                                                     # loads the address of label rvtest_data
+    mv a0, a1                                                              # set the VA to PA (identity mapping)                                          
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_W | PTE_R | PTE_V )      # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                        # setup the PTE for level0
+
+# ----------------Set the SATP and change the mode-----------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                               # set the SATP for virtualization
+    la a1,vm_en                                                            # loads the address of vm_en
+    #ifdef smode																													 
+        CHANGE_T0_S_MODE(a1)                                        	   # changes mode M to S and set the MEPC value to a1
+    #else
+        CHANGE_T0_U_MODE(a1)                                        	   # changes mode M to U and set the MEPC value to a1
+    #endif
+
+# ----------------Virtualization Enabeled-------------------------------
+
+vm_en:
+
+    li t1,10                                                               
+    
+pre_load:
+
+    TEST_PROLOG(check_load,CAUSE_LOAD_PAGE_FAULT)                           # load the addr and expected cause 
+    la a1, rvtest_data                                                      # loads the address of label rvtest_data
+
+check_load:
+
+    lw t1,0(a1)                                                             # tests the load access 
+    nop
+
+pre_store:
+
+    TEST_PROLOG(check_store,CAUSE_STORE_PAGE_FAULT)                         # load the addr and expected cause 
+    la a1,rvtest_data                                                       # loads the address of label rvtest_data
+
+check_store:
+    sw t1,0(a1)                                                             # test the store access
+    nop  
+
+    #ifdef smode
+      SMODE_ECALL                                                           # changes mode M to S and set the MEPC
+    #else
+     UMODE_ECALL                                                            # changes mode M to U and set the MEPC
+    #endif
+
+
+pre_execute:
+
+    TEST_PROLOG(check_execute,CAUSE_FETCH_PAGE_FAULT)                       # load the addr and expected cause 
+
+# -------------LEVEL 1 PTE Setup for execute test------------------------
+                                                                            # Setup a new PTE to test execute
+    la a1,check_execute                                                     # loads the address of label vm_en
+    mv a0, a1                                                               # VA = PA - Identity Map
+    ori a2, x0, ( PTE_D | PTE_A | SET_PTE_U | PTE_X )                       # sets the permission bits
+    PTE_SETUP_RV32(a1, a2, t1, a0, pgtb_l0, LEVEL0)                         # setup the PTE for level0
+
+# ----------------Set the SATP and change the mode---------------------
+
+    SATP_SETUP_SV32(pgtb_l1)                                                # set the SATP for virtualization
+    la a1,check_execute                                                     # loads the address of check_execute
+    #ifdef smode
+      CHANGE_T0_S_MODE(a1)                                                  # changes mode M to S and set the MEPC
+    #else
+      CHANGE_T0_U_MODE(a1)                                                  # changes mode M to U and set the MEPC
+    #endif
+
+
+check_execute:
+   
+    li t1, 0x45                                                             # page fault should raise 
+    j exit
+
+trap_handler:
+
+    csrr t0, mcause                                                         # read the value of mcause 
+    la t1, rvtest_check                                                     # load the address of trvtest_check
+    
+    lw t2, 0(t1)                                                            # if cause expected then load 1 else 0
+    lw t3, 4(t1)                                                            # load the expected value of mepc 
+    lw t4, 8(t1)                                                            # load the expected value of mcause  
+
+    li  t1, CAUSE_SUPERVISOR_ECALL                                          # load the value of supervisor ecall
+    beq t0,t1,next_instr                                                    # checks if ecall is occured
+
+    li  t1, CAUSE_USER_ECALL                                                # load the value of user ecall
+    beq t0,t1,next_instr                                                    # checks for ecall is occured
+
+    beqz t2, exit                                                           # Jumps to exit if cause is not expected
+ 
+    csrr t5,mepc                                                            # read the value of mepc 
+    bne t3,t5,exit                                                          # check the value of mepc with it's expected value
+
+    bne  t0, t4, exit                                                       # jumps to exit if EXPECTED_CAUSE is'nt equal to mcause
+
+    li t5, CAUSE_FETCH_PAGE_FAULT                                           # load the value of fetch page fault exception 
+    beq t0,t5,next_instr                                                    # if fetch page fault jump to next instr in M mode
+
+
+continue_execution:
+
+    INCREMENT_MEPC    _SUMODE_                                              # update the value of mepc 
+    mret                                                                    # return 
+
+next_instr:
+
+    INCREMENT_MEPC    _MMODE_                                               # update the value of mepc 
+    li t1,MSTATUS_MPP                                                       # update the MPP to MSTATUS_MPP for M mode
+    csrs mstatus,t1                                                         # update the value mstatus MPP 
+    mret                                                                    # return 
+
+
+COREV_VERIF_EXIT_LOGIC                                                      # Exit logic 
+
+.data  
+.align                                                                     
+    rvtest_check: 
+      .word 0xdeadbeef                                                      # 1 for cause expected 0  for no cause 
+      .word 0xbeefdead                                                      # write the value of mepc here (where  cause is expected)
+      .word 0xcafecafe                                                      # write the value of expect cause 
+.align 12                                     
+    rvtest_data:   
+      .word 0xbeefcafe                                                 
+      .word 0xdeadcafe                                                 
+      .word 0x00000000                                                 
+      .word 0x00000000 
+.align 12                                                      
+    pgtb_l1:                                                       
+        .zero 4096                                                 
+    pgtb_l0:                                                       
+        .zero 4096                                                                                                     
+
+.align 4; .global tohost;   tohost:   .dword 0;
+.align 4; .global fromhost; fromhost: .dword 0;

--- a/cva6/tests/testlist_riscv-mmu-cv32a60x.yaml
+++ b/cva6/tests/testlist_riscv-mmu-cv32a60x.yaml
@@ -1,0 +1,56 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+## C
+
+- test: rv32ua-v-lrsc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DENTROPY=0x1 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/custom/vm_invalid_pte01.S
+
+- test: rv32ua-v-lrsc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DENTROPY=0x1 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/custom/vm_invalid_pte02.S
+
+- test: rv32ua-v-lrsc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DENTROPY=0x1 -static -Dsmdoe=True -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/custom/vm_invalid_pte01.S
+
+- test: rv32ua-v-lrsc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DENTROPY=0x1 -static -Dsmdoe=True -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/custom/vm_invalid_pte02.S


### PR DESCRIPTION
## [Test for In-Valid Permission of PTE](https://github.com/10x-Engineers/core-v-verif/commit/7e486adaf21f458111f45f680bb50344508d4fc9)

I've added a new test case to cover scenarios involving invalid permissions of Page Table Entries (PTEs). When a PTE does not have valid permission (pte.V=0), attempting to access it will result in a page fault exception of the corresponding access type.

The test cases are specifically designed for situations when satp.mode=sv32 and the PTE has (r,w,x) PMP (Physical Memory Protection) permissions. The following tests have been implemented and executed in both supervisor and user privilege modes for both level0 and level1 PTEs:

1. Set PTE.V = 0 and test read access.
2. Set PTE.V = 0 and test write access.
3. Set PTE.V = 0 and test execute access.

Please review the changes and let me know if any further adjustments or additions are needed. Your feedback is highly appreciated!

#### Files and their purpose:

|   **`File Name`**   	|  **`Mode`**  	| **`Level`** 	| **`Testing For`** 	| 
|:------------------------:|:------------------:|:-----------------:|:-------------------------:|
| **[vm_invalid_pte_01.S](https://github.com/10x-Engineers/core-v-verif/commit/7e486adaf21f458111f45f680bb50344508d4fc9#diff-d3713a17bd2553f3fc0678d9004afb3e3141636ff89cd3ae255bb7575baa3ce9)** 	|   Supervisor /User	|     1     	|        RWX Access  	|
| **[vm_invalid_pte_02.S](https://github.com/10x-Engineers/core-v-verif/commit/7e486adaf21f458111f45f680bb50344508d4fc9#diff-7b121747f1e1ca5cca878160c1867084f76fc825b044179a77384ea4ed338fef)** 	|   Supervisor /User	|     0    	|    	 RWX Access     	|   

**YAML File** 
[testlist_riscv-mmu-cv32a60x.yaml](https://github.com/10x-Engineers/core-v-verif/commit/7e486adaf21f458111f45f680bb50344508d4fc9#diff-99dc7616197d245b3e0c2162050f3ef81205f9f36517f52b6acb4338b2690d9e) 

**MACRO File**
[macros.h](https://github.com/10x-Engineers/core-v-verif/commit/7e486adaf21f458111f45f680bb50344508d4fc9#diff-179db93f75765bbd7fa4d3eba488f2dc57255b406e55d9cd1d741f79e068058b)



To run the tests on core-v-verif use this command `./cva6/regress/dv-riscv-arch-test.sh`

